### PR TITLE
feat: add HTTP transport via StreamableHTTPServerTransport

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,18 +10,18 @@ Build a Model Context Protocol (MCP) server that provides structured tools for P
 │                  Claude Desktop / CLI                        │
 └─────────────────────────────────────────────────────────────┘
                               │
-                              │ SSE (HTTPS) / stdio
+                              │ Streamable HTTP (HTTPS) / stdio
                               ▼
 ┌─────────────────────────────────────────────────────────────┐
 │                   mcp-homelab (K3s Pod)                      │
 │  ┌─────────────┐  ┌──────────────┐  ┌───────────────────┐  │
 │  │ MCP Server  │  │ K8s Client   │  │ SSH Client (NAS)  │  │
-│  │ (stdio/SSE) │  │ (in-cluster) │  │ (node-ssh)        │  │
+│  │(stdio/HTTP) │  │ (in-cluster) │  │ (node-ssh)        │  │
 │  └─────────────┘  └──────────────┘  └───────────────────┘  │
 └─────────────────────────────────────────────────────────────┘
          │                    │                    │
          ▼                    ▼                    ▼
-   Ingress (SSE)       K8s API Server        Synology NAS
+   Ingress (HTTP)      K8s API Server        Synology NAS
    mcp.lab.mtgibbs.dev (ServiceAccount)      (SSH @ 192.168.1.60)
 ```
 
@@ -155,7 +155,7 @@ Only these deployments can be restarted via `restart_deployment`:
 |------|-------|---------|
 | `synology-mcp-ssh` | `private-key` | SSH key for NAS operations |
 | `jellyfin-api-key` | `api-key` | Jellyfin API for metadata refresh |
-| `mcp-homelab-api-key` | `api-key` | SSE endpoint authentication |
+| `mcp-homelab-api-key` | `api-key` | HTTP endpoint authentication |
 
 ## Development
 
@@ -238,7 +238,7 @@ export const myNewTool: Tool = {
 - Check RBAC: `kubectl auth can-i list pods --as=system:serviceaccount:mcp-homelab:mcp-homelab`
 - Check secrets synced: `kubectl get externalsecrets -n mcp-homelab`
 
-### SSE connection fails
+### HTTP connection fails
 - Verify Tailscale connected
 - Check API key in request header
 - Check ingress: `kubectl describe ingress mcp-homelab -n mcp-homelab`

--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that p
 │                  Claude Desktop / CLI                         │
 └──────────────────────────────────────────────────────────────┘
                               │
-                              │ SSE (HTTPS) / stdio
+                              │ Streamable HTTP (HTTPS) / stdio
                               ▼
 ┌──────────────────────────────────────────────────────────────┐
 │                   mcp-homelab (K3s Pod)                       │
 │  ┌─────────────┐  ┌──────────────┐  ┌────────────────────┐  │
 │  │ MCP Server  │  │ K8s Client   │  │ SSH Client (NAS)   │  │
-│  │ (stdio/SSE) │  │ (in-cluster) │  │ (node-ssh)         │  │
+│  │(stdio/HTTP) │  │ (in-cluster) │  │ (node-ssh)         │  │
 │  └─────────────┘  └──────────────┘  └────────────────────┘  │
 └──────────────────────────────────────────────────────────────┘
          │                    │                    │
          ▼                    ▼                    ▼
-   Ingress (SSE)       K8s API Server        Synology NAS
+   Ingress (HTTP)      K8s API Server        Synology NAS
                        (ServiceAccount)      (SSH)
 ```
 
@@ -269,9 +269,9 @@ export const tools: Tool[] = [
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `MCP_TRANSPORT` | no | `stdio` | Transport mode: `stdio` or `sse` |
-| `MCP_PORT` | no | `3000` | Port for SSE transport |
-| `MCP_API_KEY` | for SSE | — | API key for SSE endpoint authentication (`X-API-Key` header) |
+| `MCP_TRANSPORT` | no | `stdio` | Transport mode: `stdio` or `http` |
+| `MCP_PORT` | no | `3000` | Port for HTTP transport |
+| `MCP_API_KEY` | for HTTP | — | API key for HTTP endpoint authentication (`X-API-Key` header) |
 | `NAS_HOST` | for NAS tools | — | Synology NAS IP/hostname |
 | `NAS_USER` | for NAS tools | — | SSH username for NAS |
 | `NAS_PRIVATE_KEY` | for NAS tools | — | SSH private key for NAS access |
@@ -289,7 +289,7 @@ All secrets are stored in a single 1Password item named `mcp-homelab`. Create th
 
 | Field | Description |
 |-------|-------------|
-| `api-key` | API key for authenticating SSE connections |
+| `api-key` | API key for authenticating HTTP connections |
 | `nas-private-key` | Ed25519 SSH private key for Synology NAS access |
 | `jellyfin-api-key` | Jellyfin API key (generate in Jellyfin Dashboard > API Keys) |
 | `pihole-api-token` | Pi-hole API token (found in Pi-hole Admin > Settings > API) |
@@ -330,7 +330,7 @@ The `k8s/externalsecret.yaml` manifest syncs these fields into a Kubernetes secr
 ### Defense in Depth
 
 1. **Network** — Ingress only accessible via Tailscale
-2. **Authentication** — API key required in `X-API-Key` header for SSE transport
+2. **Authentication** — API key required in `X-API-Key` header for HTTP transport
 3. **Kubernetes RBAC** — ServiceAccount with minimal permissions (read-only for most resources, limited write for specific operations)
 4. **Application Layer** — Deployment restart whitelist enforced in code, NAS path allowlist enforced in code
 5. **NAS Access** — Path sanitization (shell metacharacter stripping, traversal rejection), configurable path prefix allowlist, dedicated low-privilege SSH user

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           env:
             # Transport config
             - name: MCP_TRANSPORT
-              value: "sse"
+              value: "http"
             - name: MCP_PORT
               value: "3000"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@kubernetes/client-node": "^0.21.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
+        "express": "^5.2.1",
         "node-ssh": "^13.2.0"
       },
       "devDependencies": {
+        "@types/express": "^5.0.6",
         "@types/node": "^20.11.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
@@ -1143,16 +1145,69 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/caseless": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
       "license": "MIT"
     },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1171,6 +1226,20 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/request": {
       "version": "2.48.13",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
@@ -1181,6 +1250,27 @@
         "@types/node": "*",
         "@types/tough-cookie": "*",
         "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
   "dependencies": {
     "@kubernetes/client-node": "^0.21.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "express": "^5.2.1",
     "node-ssh": "^13.2.0"
   },
   "devDependencies": {
+    "@types/express": "^5.0.6",
     "@types/node": "^20.11.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,75 @@
+import { randomUUID } from 'node:crypto';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import express from 'express';
 import { createServer } from './server.js';
+import { requireAuth } from './auth.js';
 
 const transport = process.env.MCP_TRANSPORT || 'stdio';
+const port = parseInt(process.env.MCP_PORT || '3000', 10);
 
 async function main(): Promise<void> {
-  const server = createServer();
-
   if (transport === 'stdio') {
+    const server = createServer();
     const stdioTransport = new StdioServerTransport();
     await server.connect(stdioTransport);
     console.error('MCP server running on stdio');
+  } else if (transport === 'http') {
+    const app = express();
+    app.use(express.json());
+
+    // Health endpoint (no auth required)
+    app.get('/health', (_req, res) => {
+      res.json({ status: 'ok' });
+    });
+
+    // Session management
+    const sessions = new Map<string, StreamableHTTPServerTransport>();
+
+    // MCP endpoint handles GET (SSE stream), POST (messages), DELETE (close session)
+    app.all('/mcp', async (req, res) => {
+      // Auth check
+      try {
+        requireAuth(req.headers as Record<string, string>);
+      } catch {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+      if (sessionId && sessions.has(sessionId)) {
+        const sessionTransport = sessions.get(sessionId)!;
+        await sessionTransport.handleRequest(req, res, req.body);
+      } else if (!sessionId && req.method === 'POST') {
+        // New session initialization
+        const httpTransport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: (): string => randomUUID(),
+        });
+
+        const server = createServer();
+        await server.connect(httpTransport);
+
+        const sid = httpTransport.sessionId;
+        if (sid) {
+          sessions.set(sid, httpTransport);
+          httpTransport.onclose = (): void => {
+            sessions.delete(sid);
+          };
+        }
+
+        await httpTransport.handleRequest(req, res, req.body);
+      } else if (sessionId) {
+        // Session ID provided but not found
+        res.status(404).json({ error: 'Session not found' });
+      } else {
+        res.status(400).json({ error: 'Bad request' });
+      }
+    });
+
+    app.listen(port, '0.0.0.0', () => {
+      console.error(`MCP server running on http://0.0.0.0:${port}`);
+    });
   } else {
     console.error(`Unknown transport: ${transport}`);
     process.exit(1);


### PR DESCRIPTION
## Summary
- Adds `http` transport mode using the MCP SDK's `StreamableHTTPServerTransport` with Express, fixing the pod crash caused by the unsupported `sse` transport value
- Exposes `/health` for K8s liveness/readiness probes and `/mcp` for MCP protocol traffic with per-session management and API key auth
- Updates `k8s/deployment.yaml` to use `MCP_TRANSPORT=http` and updates all SSE references in docs

## Test plan
- [x] TypeScript build passes
- [x] ESLint passes with zero issues
- [x] All 6 existing tests pass
- [ ] Container build succeeds in CI
- [ ] Deploy to cluster and verify pod starts and passes health checks
- [ ] Verify Claude Desktop can connect via `https://mcp.lab.mtgibbs.dev/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)