### PR TITLE
feat: add 6 diagnostic tools for network debugging and pod logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ This server provides a safe, structured interface for LLMs (like Claude) to inte
 - **Stats:** detailed library statistics and active session monitoring.
 - **Management:** Search media libraries and trigger metadata refreshes for specific items.
 
+### Network Diagnostics
+- **Node Networking:** Inspect interfaces, addresses, routes, and routing rules on any cluster node.
+- **Firewall Rules:** Dump iptables/ip6tables rules by table and chain.
+- **Connection Tracking:** View conntrack entries with source/destination filtering.
+- **Ingress Testing:** Curl ingress URLs from within the cluster with detailed timing.
+- **Connectivity Testing:** Ping and TCP port checks between nodes and targets.
+- **Pod Logs:** Retrieve pod logs with container, time range, and line count filtering.
+
 ### Infrastructure
 - **Certificates:** Monitor cert-manager certificate expiry and readiness.
 - **NAS Integration:** Securely touch specific paths on a Synology NAS (via SSH) to trigger file system events.
@@ -36,7 +44,7 @@ This project is built with a "defense in depth" approach:
 1.  **Least Privilege:** Runs with a dedicated ServiceAccount.
     -   **Read-Only:** Most resources (Pods, Events, Flux, Certs).
     -   **Scoped Action:** `patch` is strictly limited to whitelisted deployments and Flux resources.
-    -   **Scoped Exec:** `pod/exec` is strictly limited to `jellyfin` and `pihole` namespaces via specific Roles.
+    -   **Scoped Exec:** `pod/exec` is strictly limited to `jellyfin`, `pihole`, and `mcp-homelab` (debug-agent) namespaces via specific Roles.
 2.  **Input Validation:** Strict validation on all tool inputs (especially for file paths and resource names).
 3.  **Authentication:** Requires `X-API-Key` header for all requests.
 4.  **Network:** Designed to run behind an Ingress accessible only via Tailscale.
@@ -99,3 +107,5 @@ The server is designed to be deployed as a Pod in your cluster.
 | **Backups** | `get_backup_status`, `trigger_backup` |
 | **Secrets** | `get_secrets_status`, `refresh_secret` |
 | **System** | `get_certificate_status`, `get_ingress_status`, `touch_nas_path` |
+| **Networking** | `get_node_networking`, `get_iptables_rules`, `get_conntrack_entries`, `curl_ingress`, `test_pod_connectivity` |
+| **Logs** | `get_pod_logs` |

--- a/k8s/clusterrole.yaml
+++ b/k8s/clusterrole.yaml
@@ -9,6 +9,7 @@ rules:
   - apiGroups: [""]
     resources:
       - pods
+      - pods/log
       - services
       - nodes
       - events

--- a/k8s/debug-agent-daemonset.yaml
+++ b/k8s/debug-agent-daemonset.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: mcp-debug-agent
+  namespace: mcp-homelab
+  labels:
+    app.kubernetes.io/name: mcp-debug-agent
+    app.kubernetes.io/part-of: mcp-homelab
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mcp-debug-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mcp-debug-agent
+    spec:
+      serviceAccountName: mcp-homelab
+      hostNetwork: true
+      hostPID: true
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: netshoot
+          image: nicolaka/netshoot:v0.13
+          command: ["sleep", "infinity"]
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi

--- a/k8s/debug-agent-role.yaml
+++ b/k8s/debug-agent-role.yaml
@@ -1,0 +1,29 @@
+# Role for exec into debug-agent pods in mcp-homelab namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mcp-homelab-debug-agent-exec
+  namespace: mcp-homelab
+  labels:
+    app.kubernetes.io/name: mcp-homelab
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods/exec
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mcp-homelab-debug-agent-exec
+  namespace: mcp-homelab
+  labels:
+    app.kubernetes.io/name: mcp-homelab
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mcp-homelab-debug-agent-exec
+subjects:
+  - kind: ServiceAccount
+    name: mcp-homelab
+    namespace: mcp-homelab

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -12,6 +12,8 @@ resources:
   - service.yaml
   - ingress.yaml
   - externalsecret.yaml
+  - debug-agent-daemonset.yaml
+  - debug-agent-role.yaml
 
 commonLabels:
   app.kubernetes.io/part-of: homelab

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { tools } from '../tools/index.js';
 import { isDeploymentAllowed, getAllowedDeployments } from '../utils/whitelist.js';
+import { parseIptablesSave, parseConntrack, parsePing } from '../utils/parsers.js';
 
 describe('tool registry', () => {
   it('registers all expected tools', () => {
@@ -24,6 +25,18 @@ describe('tool registry', () => {
     expect(toolNames).toContain('update_pihole_gravity');
     expect(toolNames).toContain('get_pihole_whitelist');
     expect(toolNames).toContain('get_pihole_queries');
+    // Networking diagnostic tools
+    expect(toolNames).toContain('get_node_networking');
+    expect(toolNames).toContain('get_iptables_rules');
+    expect(toolNames).toContain('get_conntrack_entries');
+    expect(toolNames).toContain('curl_ingress');
+    expect(toolNames).toContain('test_pod_connectivity');
+    // Log tools
+    expect(toolNames).toContain('get_pod_logs');
+  });
+
+  it('has the expected total tool count', () => {
+    expect(tools).toHaveLength(25);
   });
 
   it('has no duplicate tool names', () => {
@@ -61,5 +74,93 @@ describe('deployment whitelist', () => {
     const allowed = getAllowedDeployments();
     expect(allowed).toHaveLength(6);
     expect(allowed).toContain('jellyfin/jellyfin');
+  });
+});
+
+describe('parsers', () => {
+  describe('parseIptablesSave', () => {
+    it('parses iptables-save output', () => {
+      const input = `*filter
+:INPUT ACCEPT [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [0:0]
+-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT
+-A INPUT -p tcp --dport 22 -j ACCEPT
+-A FORWARD -i cni0 -j ACCEPT
+COMMIT`;
+
+      const result = parseIptablesSave(input);
+      expect(result.table).toBe('filter');
+      expect(result.chains).toHaveLength(3);
+
+      const input_chain = result.chains.find((c) => c.name === 'INPUT');
+      expect(input_chain?.policy).toBe('ACCEPT');
+      expect(input_chain?.rules).toHaveLength(2);
+
+      const forward_chain = result.chains.find((c) => c.name === 'FORWARD');
+      expect(forward_chain?.policy).toBe('DROP');
+      expect(forward_chain?.rules).toHaveLength(1);
+    });
+  });
+
+  describe('parseConntrack', () => {
+    it('parses conntrack output', () => {
+      const input = `tcp      6 300 ESTABLISHED src=10.0.0.1 dst=10.0.0.2 sport=54321 dport=80 src=10.0.0.2 dst=10.0.0.1 sport=80 dport=54321 [ASSURED] mark=0 use=1
+udp      17 30 src=10.0.0.1 dst=8.8.8.8 sport=12345 dport=53 src=8.8.8.8 dst=10.0.0.1 sport=53 dport=12345 [ASSURED] mark=0 use=1`;
+
+      const entries = parseConntrack(input);
+      expect(entries).toHaveLength(2);
+
+      expect(entries[0].protocol).toBe('tcp');
+      expect(entries[0].state).toBe('ESTABLISHED');
+      expect(entries[0].src).toBe('10.0.0.1');
+      expect(entries[0].dst).toBe('10.0.0.2');
+      expect(entries[0].sport).toBe('54321');
+      expect(entries[0].dport).toBe('80');
+      expect(entries[0].replySrc).toBe('10.0.0.2');
+      expect(entries[0].replyDst).toBe('10.0.0.1');
+
+      expect(entries[1].protocol).toBe('udp');
+      expect(entries[1].state).toBeNull();
+      expect(entries[1].src).toBe('10.0.0.1');
+      expect(entries[1].dst).toBe('8.8.8.8');
+    });
+  });
+
+  describe('parsePing', () => {
+    it('parses successful ping output', () => {
+      const input = `PING 10.0.0.1 (10.0.0.1) 56(84) bytes of data.
+64 bytes from 10.0.0.1: icmp_seq=1 ttl=64 time=0.123 ms
+64 bytes from 10.0.0.1: icmp_seq=2 ttl=64 time=0.456 ms
+64 bytes from 10.0.0.1: icmp_seq=3 ttl=64 time=0.789 ms
+
+--- 10.0.0.1 ping statistics ---
+3 packets transmitted, 3 received, 0% packet loss, time 2003ms
+rtt min/avg/max/mdev = 0.123/0.456/0.789/0.272 ms`;
+
+      const result = parsePing(input);
+      expect(result.host).toBe('10.0.0.1');
+      expect(result.transmitted).toBe(3);
+      expect(result.received).toBe(3);
+      expect(result.lossPercent).toBe(0);
+      expect(result.rttMin).toBe(0.123);
+      expect(result.rttAvg).toBe(0.456);
+      expect(result.rttMax).toBe(0.789);
+    });
+
+    it('parses failed ping output', () => {
+      const input = `PING 10.0.0.99 (10.0.0.99) 56(84) bytes of data.
+
+--- 10.0.0.99 ping statistics ---
+3 packets transmitted, 0 received, 100% packet loss, time 2003ms`;
+
+      const result = parsePing(input);
+      expect(result.host).toBe('10.0.0.99');
+      expect(result.transmitted).toBe(3);
+      expect(result.received).toBe(0);
+      expect(result.lossPercent).toBe(100);
+      expect(result.rttMin).toBeNull();
+      expect(result.rttAvg).toBeNull();
+    });
   });
 });

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,6 +7,8 @@ import { backupTools } from './backups.js';
 import { ingressTools } from './ingress.js';
 import { tailscaleTools } from './tailscale.js';
 import { mediaTools } from './media.js';
+import { networkingTools } from './networking.js';
+import { logsTools } from './logs.js';
 
 export interface Tool {
   name: string;
@@ -29,6 +31,8 @@ export const tools: Tool[] = [
   ...ingressTools,
   ...tailscaleTools,
   ...mediaTools,
+  ...networkingTools,
+  ...logsTools,
 ];
 
 const toolMap = new Map(tools.map((t) => [t.name, t]));

--- a/src/tools/logs.ts
+++ b/src/tools/logs.ts
@@ -1,0 +1,120 @@
+import type { Tool } from './index.js';
+import { readPodLog, listPods } from '../clients/kubernetes.js';
+import { validationError, k8sError, notFoundError } from '../utils/errors.js';
+
+const DNS_1123_RE = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+const SINCE_RE = /^(\d+)(s|m|h|d)$/;
+const MAX_LOG_BYTES = 50 * 1024; // 50KB
+
+function parseSinceToSeconds(since: string): number | null {
+  const match = since.match(SINCE_RE);
+  if (!match) return null;
+
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+
+  switch (unit) {
+    case 's': return value;
+    case 'm': return value * 60;
+    case 'h': return value * 3600;
+    case 'd': return value * 86400;
+    default: return null;
+  }
+}
+
+const getPodLogs: Tool = {
+  name: 'get_pod_logs',
+  description: 'Get logs from a pod, with support for container selection, line limits, time filtering, and previous container logs',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      namespace: { type: 'string', description: 'Pod namespace' },
+      pod: { type: 'string', description: 'Pod name (exact or prefix match)' },
+      container: { type: 'string', description: 'Container name (optional, defaults to first container)' },
+      lines: { type: 'number', description: 'Number of lines to return (default: 100, max: 1000)', default: 100 },
+      since: { type: 'string', description: 'Show logs since duration (e.g. "5m", "1h", "30s")' },
+      previous: { type: 'boolean', description: 'Get logs from previous container instance', default: false },
+    },
+    required: ['namespace', 'pod'],
+  },
+  handler: async (params) => {
+    const namespace = params.namespace as string;
+    const podInput = params.pod as string;
+    const container = params.container as string | undefined;
+    const lines = Math.min(Math.max((params.lines as number) || 100, 1), 1000);
+    const since = params.since as string | undefined;
+    const previous = params.previous === true;
+
+    // Validate namespace
+    if (!DNS_1123_RE.test(namespace)) {
+      return validationError('Invalid namespace. Must match DNS-1123 format (lowercase alphanumeric and hyphens)');
+    }
+
+    // Validate since format
+    let sinceSeconds: number | undefined;
+    if (since) {
+      const parsed = parseSinceToSeconds(since);
+      if (parsed === null) {
+        return validationError('Invalid since format. Use format like "30s", "5m", "1h", "2d"');
+      }
+      sinceSeconds = parsed;
+    }
+
+    try {
+      // Find the pod — support prefix matching
+      let podName = podInput;
+
+      if (!DNS_1123_RE.test(podInput)) {
+        // Try prefix match if it doesn't look like an exact pod name
+        const pods = await listPods(namespace);
+        const match = pods.find((p) => p.metadata?.name?.startsWith(podInput));
+        if (!match || !match.metadata?.name) {
+          return notFoundError(`Pod matching '${podInput}' in namespace '${namespace}'`);
+        }
+        podName = match.metadata.name;
+      } else {
+        // Even for valid names, check if it's a prefix
+        const pods = await listPods(namespace);
+        const exact = pods.find((p) => p.metadata?.name === podInput);
+        if (!exact) {
+          const prefix = pods.find((p) => p.metadata?.name?.startsWith(podInput));
+          if (prefix?.metadata?.name) {
+            podName = prefix.metadata.name;
+          }
+          // If neither found, try anyway — the K8s API will return a clear error
+        }
+      }
+
+      const logText = await readPodLog(namespace, podName, {
+        container,
+        tailLines: lines,
+        sinceSeconds,
+        previous,
+      });
+
+      // Truncate to prevent response bloat
+      let output = logText;
+      let truncated = false;
+      if (output.length > MAX_LOG_BYTES) {
+        output = output.substring(output.length - MAX_LOG_BYTES);
+        truncated = true;
+      }
+
+      const logLines = output.split('\n').filter((l) => l.length > 0);
+
+      return {
+        namespace,
+        pod: podName,
+        ...(container && { container }),
+        ...(previous && { previous: true }),
+        lineCount: logLines.length,
+        truncated,
+        logs: output,
+      };
+    } catch (error) {
+      return k8sError(error);
+    }
+  },
+};
+
+export const logsTools = [getPodLogs];

--- a/src/tools/networking.ts
+++ b/src/tools/networking.ts
@@ -1,0 +1,380 @@
+import type { Tool } from './index.js';
+import { execOnNode } from '../utils/debug-agent.js';
+import { validateNodeName } from '../utils/node-validation.js';
+import { validationError, k8sError } from '../utils/errors.js';
+import { parseIptablesSave, parseConntrack, parsePing } from '../utils/parsers.js';
+
+const DNS_1123_RE = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+const getNodeNetworking: Tool = {
+  name: 'get_node_networking',
+  description: 'Get network interfaces, addresses, routes, and routing rules for a cluster node',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      node: { type: 'string', description: 'Node name to inspect' },
+    },
+    required: ['node'],
+  },
+  handler: async (params) => {
+    const node = params.node as string;
+
+    const nodeError = await validateNodeName(node);
+    if (nodeError) return validationError(nodeError);
+
+    try {
+      const separator = '---MCP_SEPARATOR---';
+      const result = await execOnNode(node, [
+        'sh', '-c',
+        [
+          'ip -j link show',
+          `echo '${separator}'`,
+          'ip -j addr show',
+          `echo '${separator}'`,
+          'ip -j route show',
+          `echo '${separator}'`,
+          'ip -j rule show',
+        ].join(' && '),
+      ]);
+
+      const sections = result.stdout.split(separator).map((s) => s.trim());
+
+      const parseSection = (section: string): unknown => {
+        try {
+          return JSON.parse(section);
+        } catch {
+          return section;
+        }
+      };
+
+      return {
+        node,
+        interfaces: parseSection(sections[0] || '[]'),
+        addresses: parseSection(sections[1] || '[]'),
+        routes: parseSection(sections[2] || '[]'),
+        rules: parseSection(sections[3] || '[]'),
+        exitCode: result.exitCode,
+        ...(result.stderr && { stderr: result.stderr.trim() }),
+      };
+    } catch (error) {
+      return k8sError(error);
+    }
+  },
+};
+
+const VALID_TABLES = ['filter', 'nat', 'mangle', 'raw'] as const;
+const CHAIN_RE = /^[A-Z][A-Z0-9_-]*$/;
+
+const getIptablesRules: Tool = {
+  name: 'get_iptables_rules',
+  description: 'Get iptables rules for a specific table on a cluster node',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      node: { type: 'string', description: 'Node name to inspect' },
+      table: {
+        type: 'string',
+        description: 'iptables table (filter, nat, mangle, raw)',
+        enum: ['filter', 'nat', 'mangle', 'raw'],
+        default: 'filter',
+      },
+      chain: { type: 'string', description: 'Filter to a specific chain (e.g. FORWARD, POSTROUTING)' },
+      ipv6: { type: 'boolean', description: 'Use ip6tables instead of iptables', default: false },
+    },
+    required: ['node'],
+  },
+  handler: async (params) => {
+    const node = params.node as string;
+    const table = (params.table as string) || 'filter';
+    const chain = params.chain as string | undefined;
+    const ipv6 = params.ipv6 === true;
+
+    const nodeError = await validateNodeName(node);
+    if (nodeError) return validationError(nodeError);
+
+    if (!VALID_TABLES.includes(table as typeof VALID_TABLES[number])) {
+      return validationError(`Invalid table '${table}'. Valid tables: ${VALID_TABLES.join(', ')}`);
+    }
+
+    if (chain && !CHAIN_RE.test(chain)) {
+      return validationError('Invalid chain name. Must match /^[A-Z][A-Z0-9_-]*$/');
+    }
+
+    try {
+      const cmd = ipv6 ? 'ip6tables-save' : 'iptables-save';
+      const result = await execOnNode(node, [cmd, '-t', table]);
+
+      const parsed = parseIptablesSave(result.stdout);
+
+      if (chain) {
+        parsed.chains = parsed.chains.filter((c) => c.name === chain);
+      }
+
+      return {
+        node,
+        ipVersion: ipv6 ? 6 : 4,
+        ...parsed,
+        exitCode: result.exitCode,
+        ...(result.stderr && { stderr: result.stderr.trim() }),
+      };
+    } catch (error) {
+      return k8sError(error);
+    }
+  },
+};
+
+const CONNTRACK_FILTER_RE = /^[a-zA-Z0-9.:/]+$/;
+
+const getConntrackEntries: Tool = {
+  name: 'get_conntrack_entries',
+  description: 'Get connection tracking entries from a cluster node',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      node: { type: 'string', description: 'Node name to inspect' },
+      filter: { type: 'string', description: 'Filter by source or destination IP/CIDR' },
+      limit: { type: 'number', description: 'Max entries to return (default: 50, max: 200)', default: 50 },
+    },
+    required: ['node'],
+  },
+  handler: async (params) => {
+    const node = params.node as string;
+    const filter = params.filter as string | undefined;
+    const limit = Math.min(Math.max((params.limit as number) || 50, 1), 200);
+
+    const nodeError = await validateNodeName(node);
+    if (nodeError) return validationError(nodeError);
+
+    if (filter && !CONNTRACK_FILTER_RE.test(filter)) {
+      return validationError('Invalid filter. Must match /^[a-zA-Z0-9.:/]+$/');
+    }
+
+    try {
+      const cmd: string[] = ['conntrack', '-L'];
+      if (filter) {
+        // Detect if it's likely a source or destination and use appropriate flag
+        cmd.push('-s', filter);
+      }
+
+      const result = await execOnNode(node, cmd);
+      let entries = parseConntrack(result.stdout);
+
+      // If source filter returned nothing, try destination filter
+      if (filter && entries.length === 0) {
+        const retryResult = await execOnNode(node, ['conntrack', '-L', '-d', filter]);
+        entries = parseConntrack(retryResult.stdout);
+      }
+
+      const truncated = entries.length > limit;
+      entries = entries.slice(0, limit);
+
+      return {
+        node,
+        total: entries.length,
+        truncated,
+        ...(filter && { filter }),
+        entries,
+        exitCode: result.exitCode,
+        ...(result.stderr && !result.stderr.includes('conntrack ') && { stderr: result.stderr.trim() }),
+      };
+    } catch (error) {
+      return k8sError(error);
+    }
+  },
+};
+
+const curlIngress: Tool = {
+  name: 'curl_ingress',
+  description: 'Test HTTP(S) connectivity to an ingress URL from within the cluster',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: 'URL to test (http or https)' },
+      timeout: { type: 'number', description: 'Request timeout in seconds (default: 10, max: 30)', default: 10 },
+      fromNode: { type: 'string', description: 'Specific node to curl from (optional, uses any node if omitted)' },
+    },
+    required: ['url'],
+  },
+  handler: async (params) => {
+    const urlStr = params.url as string;
+    const timeout = Math.min(Math.max((params.timeout as number) || 10, 1), 30);
+    const fromNode = params.fromNode as string | undefined;
+
+    // Validate URL
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(urlStr);
+    } catch {
+      return validationError('Invalid URL format');
+    }
+
+    if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+      return validationError('URL scheme must be http or https');
+    }
+
+    if (fromNode) {
+      const nodeError = await validateNodeName(fromNode);
+      if (nodeError) return validationError(nodeError);
+    }
+
+    try {
+      // Determine which node to use
+      let targetNode = fromNode;
+      if (!targetNode) {
+        const { getValidNodeNames } = await import('../utils/node-validation.js');
+        const nodes = await getValidNodeNames();
+        if (nodes.length === 0) {
+          return validationError('No cluster nodes available');
+        }
+        targetNode = nodes[0];
+      }
+
+      const writeFormat = JSON.stringify({
+        statusCode: '%{http_code}',
+        totalTime: '%{time_total}',
+        dnsTime: '%{time_namelookup}',
+        connectTime: '%{time_connect}',
+        tlsTime: '%{time_appconnect}',
+        startTransfer: '%{time_starttransfer}',
+        remoteIp: '%{remote_ip}',
+        remotePort: '%{remote_port}',
+        sizeDownload: '%{size_download}',
+      });
+
+      const result = await execOnNode(targetNode, [
+        'curl', '-sk', '-o', '/dev/null',
+        '-w', writeFormat,
+        '--max-time', timeout.toString(),
+        urlStr,
+      ]);
+
+      // Parse curl -w output (values are strings, convert numbers)
+      let curlData: Record<string, string> = {};
+      try {
+        curlData = JSON.parse(result.stdout.trim()) as Record<string, string>;
+      } catch {
+        return {
+          url: urlStr,
+          node: targetNode,
+          error: true,
+          code: 'CURL_PARSE_ERROR',
+          message: 'Failed to parse curl output',
+          rawOutput: result.stdout.trim(),
+          stderr: result.stderr?.trim(),
+        };
+      }
+
+      return {
+        url: urlStr,
+        node: targetNode,
+        statusCode: parseInt(curlData.statusCode, 10) || 0,
+        timing: {
+          totalSeconds: parseFloat(curlData.totalTime) || 0,
+          dnsSeconds: parseFloat(curlData.dnsTime) || 0,
+          connectSeconds: parseFloat(curlData.connectTime) || 0,
+          tlsSeconds: parseFloat(curlData.tlsTime) || 0,
+          firstByteSeconds: parseFloat(curlData.startTransfer) || 0,
+        },
+        remote: {
+          ip: curlData.remoteIp || null,
+          port: parseInt(curlData.remotePort, 10) || null,
+        },
+        sizeBytes: parseInt(curlData.sizeDownload, 10) || 0,
+        exitCode: result.exitCode,
+        ...(result.stderr && { stderr: result.stderr.trim() }),
+      };
+    } catch (error) {
+      return k8sError(error);
+    }
+  },
+};
+
+const IP_RE = /^(\d{1,3}\.){3}\d{1,3}$/;
+const IPV6_RE = /^[0-9a-fA-F:]+$/;
+const HOSTNAME_RE = /^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?$/;
+
+const testPodConnectivity: Tool = {
+  name: 'test_pod_connectivity',
+  description: 'Test network connectivity from a cluster node to a target using ping and optional port check',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      sourceNode: { type: 'string', description: 'Node to test from' },
+      target: { type: 'string', description: 'Target IP address or hostname' },
+      port: { type: 'number', description: 'Port to test with TCP connection (optional)' },
+    },
+    required: ['sourceNode', 'target'],
+  },
+  handler: async (params) => {
+    const sourceNode = params.sourceNode as string;
+    const target = params.target as string;
+    const port = params.port as number | undefined;
+
+    const nodeError = await validateNodeName(sourceNode);
+    if (nodeError) return validationError(nodeError);
+
+    // Validate target
+    if (!IP_RE.test(target) && !IPV6_RE.test(target) && !HOSTNAME_RE.test(target)) {
+      return validationError('Invalid target. Must be an IP address or hostname');
+    }
+
+    if (!DNS_1123_RE.test(target) && !IP_RE.test(target) && !IPV6_RE.test(target)) {
+      // Additional check: allow dotted hostnames
+      if (!HOSTNAME_RE.test(target)) {
+        return validationError('Invalid target format');
+      }
+    }
+
+    if (port !== undefined && (port < 1 || port > 65535 || !Number.isInteger(port))) {
+      return validationError('Port must be an integer between 1 and 65535');
+    }
+
+    try {
+      // Run ping
+      const pingResult = await execOnNode(sourceNode, [
+        'ping', '-c', '3', '-W', '2', target,
+      ]);
+
+      const ping = parsePing(pingResult.stdout + pingResult.stderr);
+
+      const response: Record<string, unknown> = {
+        sourceNode,
+        target,
+        ping: {
+          transmitted: ping.transmitted,
+          received: ping.received,
+          lossPercent: ping.lossPercent,
+          rttMinMs: ping.rttMin,
+          rttAvgMs: ping.rttAvg,
+          rttMaxMs: ping.rttMax,
+          reachable: ping.received > 0,
+        },
+      };
+
+      // Optional TCP port check
+      if (port !== undefined) {
+        const ncResult = await execOnNode(sourceNode, [
+          'nc', '-z', '-w', '3', target, port.toString(),
+        ]);
+
+        response.tcpConnect = {
+          port,
+          open: ncResult.exitCode === 0,
+          ...(ncResult.stderr && { detail: ncResult.stderr.trim() }),
+        };
+      }
+
+      return response;
+    } catch (error) {
+      return k8sError(error);
+    }
+  },
+};
+
+export const networkingTools = [
+  getNodeNetworking,
+  getIptablesRules,
+  getConntrackEntries,
+  curlIngress,
+  testPodConnectivity,
+];

--- a/src/utils/debug-agent.ts
+++ b/src/utils/debug-agent.ts
@@ -1,0 +1,18 @@
+import { getReadyPodOnNode, execInPod } from '../clients/kubernetes.js';
+
+const DEBUG_AGENT_NAMESPACE = 'mcp-homelab';
+const DEBUG_AGENT_LABEL = 'app.kubernetes.io/name=mcp-debug-agent';
+const DEBUG_AGENT_CONTAINER = 'netshoot';
+
+export async function execOnNode(
+  node: string,
+  command: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const pod = await getReadyPodOnNode(DEBUG_AGENT_NAMESPACE, DEBUG_AGENT_LABEL, node);
+
+  if (!pod || !pod.metadata?.name) {
+    throw new Error(`No ready debug-agent pod found on node '${node}'`);
+  }
+
+  return execInPod(DEBUG_AGENT_NAMESPACE, pod.metadata.name, DEBUG_AGENT_CONTAINER, command);
+}

--- a/src/utils/node-validation.ts
+++ b/src/utils/node-validation.ts
@@ -1,0 +1,28 @@
+import { listNodes } from '../clients/kubernetes.js';
+
+let cachedNodeNames: string[] = [];
+let cacheExpiry = 0;
+const CACHE_TTL_MS = 60_000;
+
+async function refreshCache(): Promise<void> {
+  const nodes = await listNodes();
+  cachedNodeNames = nodes
+    .map((n) => n.metadata?.name)
+    .filter((name): name is string => !!name);
+  cacheExpiry = Date.now() + CACHE_TTL_MS;
+}
+
+export async function getValidNodeNames(): Promise<string[]> {
+  if (Date.now() > cacheExpiry) {
+    await refreshCache();
+  }
+  return cachedNodeNames;
+}
+
+export async function validateNodeName(node: string): Promise<string | null> {
+  const validNames = await getValidNodeNames();
+  if (!validNames.includes(node)) {
+    return `Invalid node '${node}'. Valid nodes: ${validNames.join(', ')}`;
+  }
+  return null;
+}

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -1,0 +1,184 @@
+export interface IptablesChain {
+  name: string;
+  policy: string | null;
+  rules: string[];
+}
+
+export interface IptablesTable {
+  table: string;
+  chains: IptablesChain[];
+}
+
+export function parseIptablesSave(output: string): IptablesTable {
+  const lines = output.split('\n').filter((l) => l.trim().length > 0);
+  let table = 'unknown';
+  const chainMap = new Map<string, IptablesChain>();
+
+  for (const line of lines) {
+    if (line.startsWith('*')) {
+      table = line.substring(1).trim();
+    } else if (line.startsWith(':')) {
+      // :CHAIN POLICY [packets:bytes]
+      const match = line.match(/^:(\S+)\s+(\S+)/);
+      if (match) {
+        chainMap.set(match[1], {
+          name: match[1],
+          policy: match[2] === '-' ? null : match[2],
+          rules: [],
+        });
+      }
+    } else if (line.startsWith('-A ')) {
+      // -A CHAIN ... rule
+      const spaceIdx = line.indexOf(' ', 3);
+      const chainName = spaceIdx > 0 ? line.substring(3, spaceIdx) : line.substring(3);
+      const rule = spaceIdx > 0 ? line.substring(spaceIdx + 1) : '';
+
+      let chain = chainMap.get(chainName);
+      if (!chain) {
+        chain = { name: chainName, policy: null, rules: [] };
+        chainMap.set(chainName, chain);
+      }
+      chain.rules.push(rule);
+    }
+    // Ignore COMMIT and comments
+  }
+
+  return {
+    table,
+    chains: Array.from(chainMap.values()),
+  };
+}
+
+export interface ConntrackEntry {
+  protocol: string;
+  protocolNumber: string;
+  ttl: string;
+  state: string | null;
+  src: string | null;
+  dst: string | null;
+  sport: string | null;
+  dport: string | null;
+  replySrc: string | null;
+  replyDst: string | null;
+  replySport: string | null;
+  replyDport: string | null;
+  mark: string | null;
+}
+
+export function parseConntrack(output: string): ConntrackEntry[] {
+  const lines = output.split('\n').filter((l) => l.trim().length > 0);
+  const entries: ConntrackEntry[] = [];
+
+  for (const line of lines) {
+    // Skip header/summary lines
+    if (line.startsWith('conntrack ')) continue;
+
+    const fields = line.split(/\s+/);
+    if (fields.length < 4) continue;
+
+    const entry: ConntrackEntry = {
+      protocol: fields[0],
+      protocolNumber: fields[1],
+      ttl: fields[2],
+      state: null,
+      src: null,
+      dst: null,
+      sport: null,
+      dport: null,
+      replySrc: null,
+      replyDst: null,
+      replySport: null,
+      replyDport: null,
+      mark: null,
+    };
+
+    // Check if field[3] is a state (e.g., ESTABLISHED, SYN_SENT) or a key=value
+    if (!fields[3].includes('=')) {
+      entry.state = fields[3];
+    }
+
+    // Parse key=value pairs. The second occurrence of src= marks the reply direction.
+    let seenSrc = false;
+    let inReply = false;
+    for (const field of fields.slice(3)) {
+      if (field.startsWith('[')) continue; // Skip [ASSURED], [UNREPLIED]
+
+      const eqIdx = field.indexOf('=');
+      if (eqIdx < 0) continue;
+      const key = field.substring(0, eqIdx);
+      const value = field.substring(eqIdx + 1);
+
+      // Detect reply direction by second occurrence of src=
+      if (key === 'src') {
+        if (seenSrc) {
+          inReply = true;
+        }
+        seenSrc = true;
+      }
+
+      if (inReply) {
+        if (key === 'src') entry.replySrc = value;
+        else if (key === 'dst') entry.replyDst = value;
+        else if (key === 'sport') entry.replySport = value;
+        else if (key === 'dport') entry.replyDport = value;
+      } else {
+        if (key === 'src') entry.src = value;
+        else if (key === 'dst') entry.dst = value;
+        else if (key === 'sport') entry.sport = value;
+        else if (key === 'dport') entry.dport = value;
+        else if (key === 'mark') entry.mark = value;
+      }
+    }
+
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+export interface PingResult {
+  host: string;
+  transmitted: number;
+  received: number;
+  lossPercent: number;
+  rttMin: number | null;
+  rttAvg: number | null;
+  rttMax: number | null;
+}
+
+export function parsePing(output: string): PingResult {
+  const result: PingResult = {
+    host: '',
+    transmitted: 0,
+    received: 0,
+    lossPercent: 100,
+    rttMin: null,
+    rttAvg: null,
+    rttMax: null,
+  };
+
+  // PING host (ip): data bytes
+  const hostMatch = output.match(/PING\s+(\S+)/);
+  if (hostMatch) {
+    result.host = hostMatch[1];
+  }
+
+  // 3 packets transmitted, 3 packets received, 0% packet loss
+  const statsMatch = output.match(/(\d+)\s+packets?\s+transmitted,\s+(\d+)\s+(?:packets?\s+)?received,\s+(\d+(?:\.\d+)?)%\s+packet\s+loss/);
+  if (statsMatch) {
+    result.transmitted = parseInt(statsMatch[1], 10);
+    result.received = parseInt(statsMatch[2], 10);
+    result.lossPercent = parseFloat(statsMatch[3]);
+  }
+
+  // rtt min/avg/max/mdev = 0.123/0.456/0.789/0.012 ms
+  // or: round-trip min/avg/max/stddev = ...
+  const rttMatch = output.match(/(?:rtt|round-trip)\s+min\/avg\/max\/\S+\s*=\s*([\d.]+)\/([\d.]+)\/([\d.]+)/);
+  if (rttMatch) {
+    result.rttMin = parseFloat(rttMatch[1]);
+    result.rttAvg = parseFloat(rttMatch[2]);
+    result.rttMax = parseFloat(rttMatch[3]);
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- Add 5 networking diagnostic tools (`get_node_networking`, `get_iptables_rules`, `get_conntrack_entries`, `curl_ingress`, `test_pod_connectivity`) that exec into a privileged netshoot DaemonSet for node-level network inspection
- Add `get_pod_logs` tool using the Kubernetes log API with prefix matching, time filtering, and 50KB output cap
- Add DaemonSet manifest (`nicolaka/netshoot:v0.13`) with hostNetwork/hostPID/privileged for node diagnostics, plus scoped RBAC for exec access
- Add utility modules: node name validation (cached 60s), `execOnNode()` helper, and parsers for iptables-save, conntrack, and ping output

## Test plan

- [x] `npm run lint` — passes
- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes
- [x] `npm test` — 11 tests pass (25 tools registered, no duplicates, parser unit tests)
- [ ] Deploy DaemonSet to cluster, verify pods running on all nodes
- [ ] Test `get_pod_logs` against a known pod (e.g., flux kustomize-controller)
- [ ] Test `get_node_networking` — verify JSON output shows interfaces, routes, rules
- [ ] Test `curl_ingress` against a known ingress URL
- [ ] Test `get_iptables_rules` — dump mangle table, verify MARK rules visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)