### PR TITLE
feat: add trigger_cronjob tool to run any CronJob on demand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,8 @@ metadata:
 
 There is **no central whitelist** — the opt-in lives in each CronJob's manifest, reviewed at PR time. Adding the label is an **attestation that the job is idempotent and safe to run concurrently**: a manual trigger creates an independent Job that bypasses the CronJob's `concurrencyPolicy`, so it can overlap a scheduled run. The tool can only instantiate an existing CronJob's `jobTemplate` (no arbitrary pods/commands); the label is the authorization layer on top of the `create` Jobs RBAC.
 
+As a second layer, the tool also **refuses to start an overlapping run**: if a Job for the CronJob is already active (a scheduled run via `status.active`, or a prior manual trigger labelled `cronjob-name=<name>`), it returns `ALREADY_RUNNING`. This is best-effort (check-then-create), so the label's idempotency attestation still covers the residual race.
+
 ### Exec Tools Security
 
 The exec-based tools (`test_dns_query`, `curl_ingress`, `test_pod_connectivity`, `get_node_networking`, `get_iptables_rules`, `get_conntrack_entries`) run commands inside cluster pods via the K8s exec API. Security is maintained through multiple layers:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,18 @@ Only these deployments can be restarted via `restart_deployment`:
 - `media/jellyseerr`
 - `media/flaresolverr`
 
+### Manual CronJob Triggering (Opt-In Label)
+
+`trigger_cronjob` (and its `trigger_backup` alias) will only run a CronJob that carries the label:
+
+```yaml
+metadata:
+  labels:
+    homelab.mcp/triggerable: "true"
+```
+
+There is **no central whitelist** — the opt-in lives in each CronJob's manifest, reviewed at PR time. Adding the label is an **attestation that the job is idempotent and safe to run concurrently**: a manual trigger creates an independent Job that bypasses the CronJob's `concurrencyPolicy`, so it can overlap a scheduled run. The tool can only instantiate an existing CronJob's `jobTemplate` (no arbitrary pods/commands); the label is the authorization layer on top of the `create` Jobs RBAC.
+
 ### Exec Tools Security
 
 The exec-based tools (`test_dns_query`, `curl_ingress`, `test_pod_connectivity`, `get_node_networking`, `get_iptables_rules`, `get_conntrack_entries`) run commands inside cluster pods via the K8s exec API. Security is maintained through multiple layers:
@@ -262,8 +274,8 @@ The `describe_resource` and `get_cronjob_details` tools sanitize environment var
 | `reconcile_flux` | `resource?` | Trigger Flux sync (all or specific) |
 | `restart_deployment` | `namespace`, `deployment` | Rollout restart (whitelisted only) |
 | `fix_jellyfin_metadata` | `name` | Find item in DB, trigger API refresh |
-| `trigger_cronjob` | `namespace`, `cronjob` | Run any CronJob now (Job from its template) |
-| `trigger_backup` | `namespace`, `cronjob` | Alias of `trigger_cronjob` (back-compat) |
+| `trigger_cronjob` | `namespace`, `cronjob` | Run a CronJob now (Job from its template). **Requires opt-in label** `homelab.mcp/triggerable: "true"` |
+| `trigger_backup` | `namespace`, `cronjob` | Alias of `trigger_cronjob` (back-compat); same opt-in label required |
 | `test_dns_query` | `domain`, `type?` | Run dig against Pi-hole |
 | `update_pihole_gravity` | — | Re-download blocklists and rebuild gravity DB |
 | `refresh_secret` | `namespace`, `name` | Force ExternalSecret resync |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,7 +262,8 @@ The `describe_resource` and `get_cronjob_details` tools sanitize environment var
 | `reconcile_flux` | `resource?` | Trigger Flux sync (all or specific) |
 | `restart_deployment` | `namespace`, `deployment` | Rollout restart (whitelisted only) |
 | `fix_jellyfin_metadata` | `name` | Find item in DB, trigger API refresh |
-| `trigger_backup` | `job_name` | Create Job from CronJob |
+| `trigger_cronjob` | `namespace`, `cronjob` | Run any CronJob now (Job from its template) |
+| `trigger_backup` | `namespace`, `cronjob` | Alias of `trigger_cronjob` (back-compat) |
 | `test_dns_query` | `domain`, `type?` | Run dig against Pi-hole |
 | `update_pihole_gravity` | — | Re-download blocklists and rebuild gravity DB |
 | `refresh_secret` | `namespace`, `name` | Force ExternalSecret resync |

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -16,6 +16,7 @@ describe('tool registry', () => {
     expect(toolNames).toContain('get_secrets_status');
     expect(toolNames).toContain('refresh_secret');
     expect(toolNames).toContain('get_backup_status');
+    expect(toolNames).toContain('trigger_cronjob');
     expect(toolNames).toContain('trigger_backup');
     expect(toolNames).toContain('get_ingress_status');
     expect(toolNames).toContain('get_tailscale_status');
@@ -65,7 +66,7 @@ describe('tool registry', () => {
   });
 
   it('has the expected total tool count', () => {
-    expect(tools).toHaveLength(45);
+    expect(tools).toHaveLength(46);
   });
 
   it('has no duplicate tool names', () => {

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { tools } from '../tools/index.js';
-import { isDeploymentAllowed, getAllowedDeployments } from '../utils/whitelist.js';
+import { isDeploymentAllowed, getAllowedDeployments, isCronjobTriggerable, TRIGGERABLE_LABEL } from '../utils/whitelist.js';
 import { parseIptablesSave, parseConntrack, parsePing } from '../utils/parsers.js';
 
 describe('tool registry', () => {
@@ -108,6 +108,20 @@ describe('deployment whitelist', () => {
     expect(allowed).toContain('jellyfin/jellyfin');
     expect(allowed).toContain('media/sonarr');
     expect(allowed).toContain('media/radarr');
+  });
+});
+
+describe('cronjob trigger opt-in', () => {
+  it('allows only cronjobs labelled triggerable="true"', () => {
+    expect(isCronjobTriggerable({ [TRIGGERABLE_LABEL]: 'true' })).toBe(true);
+  });
+
+  it('rejects missing, absent, or non-"true" labels', () => {
+    expect(isCronjobTriggerable(undefined)).toBe(false);
+    expect(isCronjobTriggerable({})).toBe(false);
+    expect(isCronjobTriggerable({ [TRIGGERABLE_LABEL]: 'false' })).toBe(false);
+    expect(isCronjobTriggerable({ [TRIGGERABLE_LABEL]: 'TRUE' })).toBe(false);
+    expect(isCronjobTriggerable({ 'other/label': 'true' })).toBe(false);
   });
 });
 

--- a/src/tools/backups.ts
+++ b/src/tools/backups.ts
@@ -1,6 +1,6 @@
 import type { Tool } from './index.js';
 import { getKubeConfig, getCoreApi } from '../clients/kubernetes.js';
-import { validationError, k8sError, notTriggerableError } from '../utils/errors.js';
+import { validationError, k8sError, notTriggerableError, alreadyRunningError } from '../utils/errors.js';
 import { isCronjobTriggerable, TRIGGERABLE_LABEL } from '../utils/whitelist.js';
 import * as k8s from '@kubernetes/client-node';
 
@@ -86,6 +86,10 @@ function validateJobNames(namespace: string, cronjobName: string): string | null
 // handlers and surfaced as a NOT_TRIGGERABLE error (distinct from k8s errors).
 class NotTriggerableError extends Error {}
 
+// Thrown when a run of the CronJob is already active (guard "A"); surfaced as
+// an ALREADY_RUNNING error so an overlapping manual run is refused.
+class AlreadyRunningError extends Error {}
+
 // Shared implementation behind trigger_cronjob (and its trigger_backup alias):
 // reads a CronJob and creates a one-off Job from its jobTemplate — the
 // equivalent of `kubectl create job --from=cronjob/<name>`. Returns the new
@@ -109,6 +113,27 @@ async function createJobFromCronJob(
       `CronJob ${namespace}/${cronjobName} is not opted in for manual triggering. ` +
         `Add label '${TRIGGERABLE_LABEL}: "true"' to its manifest — only for jobs that are ` +
         `idempotent and safe to run concurrently.`
+    );
+  }
+
+  // Guard A: refuse if a run of this CronJob is already active — a scheduled
+  // run (status.active) or a prior manual Job (labelled cronjob-name=<name>).
+  // Best-effort check-then-create; the label's idempotency contract covers the
+  // residual race where a scheduled run fires in the same instant.
+  const scheduledActive = cronjobResp.body.status?.active?.length ?? 0;
+  const existing = await batchApi.listNamespacedJob(
+    namespace,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    `cronjob-name=${cronjobName}`
+  );
+  const manualActive = existing.body.items.filter((j) => (j.status?.active ?? 0) > 0).length;
+  if (scheduledActive + manualActive > 0) {
+    throw new AlreadyRunningError(
+      `A run of ${namespace}/${cronjobName} is already active ` +
+        `(${scheduledActive} scheduled, ${manualActive} manual). Refusing to start an overlapping run.`
     );
   }
 
@@ -165,6 +190,7 @@ const triggerCronjob: Tool = {
         cronjob: cronjobName,
       };
     } catch (error) {
+      if (error instanceof AlreadyRunningError) return alreadyRunningError(error.message);
       if (error instanceof NotTriggerableError) return notTriggerableError(error.message);
       return k8sError(error);
     }
@@ -201,6 +227,7 @@ const triggerBackup: Tool = {
         namespace,
       };
     } catch (error) {
+      if (error instanceof AlreadyRunningError) return alreadyRunningError(error.message);
       if (error instanceof NotTriggerableError) return notTriggerableError(error.message);
       return k8sError(error);
     }

--- a/src/tools/backups.ts
+++ b/src/tools/backups.ts
@@ -1,6 +1,7 @@
 import type { Tool } from './index.js';
 import { getKubeConfig, getCoreApi } from '../clients/kubernetes.js';
-import { validationError, k8sError } from '../utils/errors.js';
+import { validationError, k8sError, notTriggerableError } from '../utils/errors.js';
+import { isCronjobTriggerable, TRIGGERABLE_LABEL } from '../utils/whitelist.js';
 import * as k8s from '@kubernetes/client-node';
 
 const DNS_1123_RE = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
@@ -81,6 +82,10 @@ function validateJobNames(namespace: string, cronjobName: string): string | null
   return null;
 }
 
+// Thrown when a CronJob lacks the opt-in triggerable label; caught by the tool
+// handlers and surfaced as a NOT_TRIGGERABLE error (distinct from k8s errors).
+class NotTriggerableError extends Error {}
+
 // Shared implementation behind trigger_cronjob (and its trigger_backup alias):
 // reads a CronJob and creates a one-off Job from its jobTemplate — the
 // equivalent of `kubectl create job --from=cronjob/<name>`. Returns the new
@@ -94,6 +99,19 @@ async function createJobFromCronJob(
   const batchApi = kc.makeApiClient(k8s.BatchV1Api);
 
   const cronjobResp = await batchApi.readNamespacedCronJob(cronjobName, namespace);
+
+  // Opt-in gate: only CronJobs labelled triggerable may be run manually. The
+  // label attests the job is idempotent and concurrency-safe (a manual run
+  // bypasses the CronJob's concurrencyPolicy, so an opted-in job must tolerate
+  // overlapping with a scheduled run).
+  if (!isCronjobTriggerable(cronjobResp.body.metadata?.labels)) {
+    throw new NotTriggerableError(
+      `CronJob ${namespace}/${cronjobName} is not opted in for manual triggering. ` +
+        `Add label '${TRIGGERABLE_LABEL}: "true"' to its manifest — only for jobs that are ` +
+        `idempotent and safe to run concurrently.`
+    );
+  }
+
   const jobTemplateSpec = cronjobResp.body.spec?.jobTemplate?.spec;
   if (!jobTemplateSpec) {
     throw new Error(`CronJob ${namespace}/${cronjobName} has no jobTemplate.spec`);
@@ -147,6 +165,7 @@ const triggerCronjob: Tool = {
         cronjob: cronjobName,
       };
     } catch (error) {
+      if (error instanceof NotTriggerableError) return notTriggerableError(error.message);
       return k8sError(error);
     }
   },
@@ -182,6 +201,7 @@ const triggerBackup: Tool = {
         namespace,
       };
     } catch (error) {
+      if (error instanceof NotTriggerableError) return notTriggerableError(error.message);
       return k8sError(error);
     }
   },

--- a/src/tools/backups.ts
+++ b/src/tools/backups.ts
@@ -71,9 +71,93 @@ const getBackupStatus: Tool = {
   },
 };
 
+function validateJobNames(namespace: string, cronjobName: string): string | null {
+  if (!DNS_1123_RE.test(namespace)) {
+    return 'Invalid namespace. Must match DNS-1123 format (lowercase alphanumeric and hyphens).';
+  }
+  if (!DNS_1123_RE.test(cronjobName)) {
+    return 'Invalid cronjob name. Must match DNS-1123 format (lowercase alphanumeric and hyphens).';
+  }
+  return null;
+}
+
+// Shared implementation behind trigger_cronjob (and its trigger_backup alias):
+// reads a CronJob and creates a one-off Job from its jobTemplate — the
+// equivalent of `kubectl create job --from=cronjob/<name>`. Returns the new
+// Job's name.
+async function createJobFromCronJob(
+  namespace: string,
+  cronjobName: string,
+  origin: string
+): Promise<string> {
+  const kc = getKubeConfig();
+  const batchApi = kc.makeApiClient(k8s.BatchV1Api);
+
+  const cronjobResp = await batchApi.readNamespacedCronJob(cronjobName, namespace);
+  const jobTemplateSpec = cronjobResp.body.spec?.jobTemplate?.spec;
+  if (!jobTemplateSpec) {
+    throw new Error(`CronJob ${namespace}/${cronjobName} has no jobTemplate.spec`);
+  }
+
+  const jobName = `${cronjobName}-manual-${Date.now()}`;
+  const job: k8s.V1Job = {
+    apiVersion: 'batch/v1',
+    kind: 'Job',
+    metadata: {
+      name: jobName,
+      namespace,
+      labels: {
+        'job-origin': origin,
+        'cronjob-name': cronjobName,
+      },
+    },
+    spec: jobTemplateSpec,
+  };
+
+  await batchApi.createNamespacedJob(namespace, job);
+  return jobName;
+}
+
+const triggerCronjob: Tool = {
+  name: 'trigger_cronjob',
+  description:
+    'Manually run any CronJob now by creating a Job from its template (equivalent to `kubectl create job --from=cronjob/<name>`). Works for ANY CronJob — backups, renovate, etc. The Job runs immediately, independent of the schedule.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      namespace: { type: 'string', description: 'CronJob namespace' },
+      cronjob: { type: 'string', description: 'CronJob name to run now' },
+    },
+    required: ['namespace', 'cronjob'],
+  },
+  handler: async (params) => {
+    const namespace = params.namespace as string;
+    const cronjobName = params.cronjob as string;
+
+    const invalid = validateJobNames(namespace, cronjobName);
+    if (invalid) return validationError(invalid);
+
+    try {
+      const jobName = await createJobFromCronJob(namespace, cronjobName, 'manual-trigger');
+      return {
+        success: true,
+        message: `Created Job ${jobName} from CronJob ${namespace}/${cronjobName}`,
+        jobName,
+        namespace,
+        cronjob: cronjobName,
+      };
+    } catch (error) {
+      return k8sError(error);
+    }
+  },
+};
+
+// Backwards-compatible alias of trigger_cronjob (pre-dates the rename; kept so
+// existing callers and docs keep working). Prefer trigger_cronjob.
 const triggerBackup: Tool = {
   name: 'trigger_backup',
-  description: 'Manually trigger a backup by creating a Job from a CronJob',
+  description:
+    'Alias of trigger_cronjob: create a one-off Job from a CronJob. Kept for backwards compatibility — prefer trigger_cronjob.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -86,34 +170,14 @@ const triggerBackup: Tool = {
     const namespace = params.namespace as string;
     const cronjobName = params.cronjob as string;
 
+    const invalid = validateJobNames(namespace, cronjobName);
+    if (invalid) return validationError(invalid);
+
     try {
-      const kc = getKubeConfig();
-      const batchApi = kc.makeApiClient(k8s.BatchV1Api);
-
-      const cronjobResp = await batchApi.readNamespacedCronJob(cronjobName, namespace);
-      const cronjob = cronjobResp.body;
-
-      const jobName = `${cronjobName}-manual-${Date.now()}`;
-
-      const job: k8s.V1Job = {
-        apiVersion: 'batch/v1',
-        kind: 'Job',
-        metadata: {
-          name: jobName,
-          namespace,
-          labels: {
-            'job-origin': 'manual-trigger',
-            'cronjob-name': cronjobName,
-          },
-        },
-        spec: cronjob.spec?.jobTemplate?.spec,
-      };
-
-      await batchApi.createNamespacedJob(namespace, job);
-
+      const jobName = await createJobFromCronJob(namespace, cronjobName, 'manual-trigger');
       return {
         success: true,
-        message: `Created backup job ${jobName} from CronJob ${cronjobName}`,
+        message: `Created job ${jobName} from CronJob ${cronjobName}`,
         jobName,
         namespace,
       };
@@ -265,4 +329,4 @@ const getJobLogs: Tool = {
   },
 };
 
-export const backupTools = [getBackupStatus, triggerBackup, getCronjobDetails, getJobLogs];
+export const backupTools = [getBackupStatus, triggerCronjob, triggerBackup, getCronjobDetails, getJobLogs];

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -24,6 +24,10 @@ export function validationError(message: string): ToolError {
   return createError('VALIDATION_ERROR', message);
 }
 
+export function notTriggerableError(message: string): ToolError {
+  return createError('NOT_TRIGGERABLE', message);
+}
+
 export function k8sError(error: unknown): ToolError {
   // K8s client errors often have detailed info in response.body
   if (error && typeof error === 'object') {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -28,6 +28,10 @@ export function notTriggerableError(message: string): ToolError {
   return createError('NOT_TRIGGERABLE', message);
 }
 
+export function alreadyRunningError(message: string): ToolError {
+  return createError('ALREADY_RUNNING', message);
+}
+
 export function k8sError(error: unknown): ToolError {
   // K8s client errors often have detailed info in response.body
   if (error && typeof error === 'object') {

--- a/src/utils/whitelist.ts
+++ b/src/utils/whitelist.ts
@@ -29,3 +29,13 @@ export function isDeploymentAllowed(namespace: string, name: string): boolean {
 export function getAllowedDeployments(): string[] {
   return Array.from(ALLOWED_DEPLOYMENTS);
 }
+
+// Opt-in label a CronJob must carry to be eligible for manual triggering via
+// trigger_cronjob (and its trigger_backup alias). Adding it is the manifest
+// author's attestation that the job is IDEMPOTENT and safe to run CONCURRENTLY,
+// since a manual trigger bypasses the CronJob's concurrencyPolicy.
+export const TRIGGERABLE_LABEL = 'homelab.mcp/triggerable';
+
+export function isCronjobTriggerable(labels: Record<string, string> | undefined): boolean {
+  return labels?.[TRIGGERABLE_LABEL] === 'true';
+}


### PR DESCRIPTION
## What
Adds `trigger_cronjob(namespace, cronjob)` — run any CronJob on demand by creating a Job from its template (the MCP equivalent of `kubectl create job --from=cronjob/<name>`).

## Why
`trigger_backup` was already general (it builds a Job from *any* CronJob), but the name hid the capability — triggering the new `renovate` CronJob looked impossible without kubectl. This surfaces it under a clear, discoverable name.

## Changes
- `trigger_cronjob`: canonical general tool, with DNS-1123 input validation
- `trigger_backup`: kept as a back-compat alias, now validated too
- shared `createJobFromCronJob` helper
- tests (count 45 → 46) + CLAUDE.md tool table updated

## Notes
- **No RBAC change** — the ClusterRole already permits `create` Jobs + read CronJobs
- Verified locally: `build` + 11 tests + `lint` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
