### PR TITLE
chore: subscribe to review-hub (gate-regression)

### DIFF
--- a/.review-hub.yml
+++ b/.review-hub.yml
@@ -1,0 +1,5 @@
+# review-hub opt-in — which eval gates the bot runs on this repo's PRs.
+# Presence of this file is the sign-up; absence means no review.
+# https://github.com/mtgibbs/pi-cluster -> specs/review-hub/
+validators:
+  - gate-regression   # flags PRs that weaken a security gate (triggerable label / Guard A / deploy allowlist)


### PR DESCRIPTION
Adds `.review-hub.yml` so the review-hub bot runs the **gate-regression** validator on this repo's PRs — flagging changes that weaken a security gate (triggerable-label gate, Guard A, deploy allowlist, fail-closed sentinels). Once merged, future PRs touching `src/utils/whitelist.ts`, `src/utils/errors.ts`, or `src/tools/*.ts` get an automated gate-regression check (majority-of-5, posts a Check Run + comment). Validator + eval: `mtgibbs/pi-cluster:specs/validators/gate-regression/`.