### PR TITLE
chore(review-hub): opt into the 6 MCP tool-safety validators

### DIFF
--- a/.review-hub.yml
+++ b/.review-hub.yml
@@ -2,4 +2,10 @@
 # Presence of this file is the sign-up; absence means no review.
 # https://github.com/mtgibbs/pi-cluster -> specs/review-hub/
 validators:
-  - gate-regression   # flags PRs that weaken a security gate (triggerable label / Guard A / deploy allowlist)
+  - gate-regression      # weakening a security gate (triggerable label / Guard A / deploy allowlist)
+  - secret-hygiene       # output secret-leakage (env/secretRef redaction, kubeconfig)
+  - input-validation     # unvalidated user input reaching a sink (k8s / exec / shell / URL)
+  - mutation-gating      # a new mutating tool shipping with no gate
+  - concurrency-safety   # active-run guard integrity (weaken / remove / unwire / raise threshold)
+  - fail-closed          # error paths that stop refusing (fail-open)
+  - read-only-integrity  # an existing read-only tool gaining a write


### PR DESCRIPTION
Opts this repo into the six single-concern MCP tool-safety validators that just
landed in `pi-cluster` (`review-hub` 0.2.0). Each is green at reps=5/majority on
its own grounded eval set; each posts its own Check Run and judges only the files
its globs match (`src/tools/*.ts`, `src/utils/*`, `src/clients/*`).

| Validator | Catches |
| :-- | :-- |
| `secret-hygiene` | a tool output leaking a secret value (env/secretRef redaction dropped, kubeconfig exported) |
| `input-validation` | user input reaching a sink (k8s name, exec, shell string, URL) with no validation |
| `mutation-gating` | a **new** mutating tool shipping with no gate |
| `concurrency-safety` | an active-run guard weakened, removed, unwired, or threshold-raised |
| `fail-closed` | an error path that stops refusing (warn-and-proceed, catch-and-succeed) |
| `read-only-integrity` | an existing read-only tool quietly gaining a write |

`gate-regression` (already active) keeps the gate-weakening concern; these six are
deliberately scoped *around* it so each stays single-purpose. Merging this to
`main` activates them on this repo's PRs (the opt-in is read from the default
branch, so a PR can't opt itself out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
