### PR TITLE
chore(review-hub): opt into no-false-green validator

### DIFF
--- a/.review-hub.yml
+++ b/.review-hub.yml
@@ -9,3 +9,4 @@ validators:
   - concurrency-safety   # active-run guard integrity (weaken / remove / unwire / raise threshold)
   - fail-closed          # error paths that stop refusing (fail-open)
   - read-only-integrity  # an existing read-only tool gaining a write
+  - no-false-green       # a status/reader tool reporting healthy/ok/empty when the check actually failed


### PR DESCRIPTION
Opts pi-cluster-mcp into **no-false-green**, the 9th review-hub validator (shipped in review-hub v0.4.0).

**What it catches:** a status / diagnostic / reader tool that reports `healthy` / `ok` / empty-but-fine when the underlying operation actually failed, errored, or was skipped — "cached success ≠ proof" turned into a gate.

**Why this one:** derived from this repo's real defect history, not the trigger-safety lens the roster grew up with. Read-path bugs dominate — #16 (404, wrong API version), #17 (broken stats reported alongside a healthy status), #18 (empty error object), the bazarr HTML-not-JSON shape. Of 12 historical defects, only 1 was caught by the existing roster; this gate covers the most frequent class.

**Eval:** precision 1.00 / recall 1.00 at reps=5 (majority-to-escalate, `max_tokens=2000`), every case unanimous 5/5 — including 3 precision traps (log-and-rethrow, the swallow-removal fix, genuine-empty-on-success).

Runs on `src/tools|clients|utils/*.ts` changes once merged. Independent Check Run, and folds into the consolidated report card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
