### PR TITLE
chore(review-hub): opt into output-bounds validator

### DIFF
--- a/.review-hub.yml
+++ b/.review-hub.yml
@@ -10,3 +10,4 @@ validators:
   - fail-closed          # error paths that stop refusing (fail-open)
   - read-only-integrity  # an existing read-only tool gaining a write
   - no-false-green       # a status/reader tool reporting healthy/ok/empty when the check actually failed
+  - output-bounds        # a tool returning unbounded list/log/stdout output (no limit/cap) that blows the caller's context


### PR DESCRIPTION
Opts pi-cluster-mcp into **output-bounds**, the 10th review-hub validator (shipped in review-hub v0.5.0).

**What it catches:** a tool returning unbounded output — logs / exec-stdout, query / download-queue / history records, search results, or a large / cluster-wide resource enumeration — with no `limit` / cap / `.slice` / page size, which would blow the LLM caller's context window (and cost per token).

**Why this one:** the second read-path gate from the holistic roster re-think. It guards output *size*, complementing no-false-green's output *honesty*. Grounded in the bounds this codebase already uses (`MAX_LOG_BYTES` 50KB, `Math.min(Math.max(n,1),50)` clamps, `.slice(0,25)`, `truncated` flags) and the real unbounded readers (`get_node_networking` full `ip -j`, `get_pvcs` cluster-wide, `get_job_logs` pod fan-out). It deliberately treats small fixed-cardinality infra lists (nodes, a handful of CRs) as safe, so it won't false-block on infra enumeration.

**Eval:** precision 1.00 / recall 1.00 at reps=5 (majority-to-escalate, `max_tokens=2000`) on the first run, every case unanimous 5/5 — including the small-infra-list precision trap.

Runs on `src/tools|clients|utils/*.ts` changes once merged. Independent Check Run, and folds into the consolidated report card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
