### PR TITLE
test: review-hub rollup smoke (empty roster)

### DIFF
--- a/ROLLUP-SMOKE-TEST.md
+++ b/ROLLUP-SMOKE-TEST.md
@@ -1,0 +1,3 @@
+# review-hub rollup smoke test
+
+Throwaway PR to confirm the always-on `review-hub` Check Run posts on an empty roster (no watched file touched). Safe to delete.


### PR DESCRIPTION
Throwaway PR to confirm the always-on `review-hub` rollup Check Run posts on an **empty roster** (touches only a root file, no watched `src/` path). Expect `review-hub` = ✅ success, title "No applicable gates". Will close + delete the branch once verified.