### PR TITLE
feat: Mealie recipe tools (status, search, get, import-from-URL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ This project is built with a "defense in depth" approach:
 | `RADARR_API_KEY` | API Key for Radarr operations | Yes (for Movie tools) |
 | `SABNZBD_URL` | Internal URL for SABnzbd | No (default: cluster svc) |
 | `SABNZBD_API_KEY` | API Key for SABnzbd operations | Yes (for Download tools) |
+| `MEALIE_URL` | Internal URL for Mealie | No (default: cluster svc) |
+| `MEALIE_API_TOKEN` | API token for Mealie operations | Yes (for Recipe tools) |
+| `MEALIE_PUBLIC_URL` | Public base URL for recipe links | No (default: recipes.lab.mtgibbs.dev) |
+| `MEALIE_GROUP_SLUG` | Group slug used in recipe web links | No (default: home) |
 
 ## 📦 Deployment
 
@@ -119,6 +123,7 @@ The server is designed to be deployed as a Pod in your cluster.
 | **Movies (Radarr)** | `get_radarr_queue`, `get_radarr_history`, `search_radarr_movie` |
 | **Downloads (SABnzbd)** | `get_sabnzbd_queue`, `get_sabnzbd_history`, `retry_sabnzbd_download`, `pause_resume_sabnzbd` |
 | **Arr Shared** | `get_quality_profile`, `reject_and_search` |
+| **Recipes (Mealie)** | `get_mealie_status`, `search_mealie_recipes`, `get_mealie_recipe`, `import_mealie_recipe_url` |
 | **Backups** | `get_backup_status`, `trigger_backup`, `get_cronjob_details`, `get_job_logs` |
 | **Secrets** | `get_secrets_status`, `refresh_secret` |
 | **Storage** | `get_pvcs` |

--- a/src/__tests__/mealie.test.ts
+++ b/src/__tests__/mealie.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { validateImportUrl, validateSlug } from '../tools/mealie.js';
+
+function isError(v: unknown): boolean {
+  return typeof v === 'object' && v !== null && (v as { error?: boolean }).error === true;
+}
+
+describe('mealie import URL gate', () => {
+  it('accepts public recipe sites', () => {
+    expect(validateImportUrl('https://www.seriouseats.com/foo-recipe')).toBeInstanceOf(URL);
+    expect(validateImportUrl('http://cooking.nytimes.com/recipes/1')).toBeInstanceOf(URL);
+  });
+
+  it('rejects non-http(s) schemes', () => {
+    expect(isError(validateImportUrl('file:///etc/passwd'))).toBe(true);
+    expect(isError(validateImportUrl('ftp://example.com/x'))).toBe(true);
+    expect(isError(validateImportUrl('gopher://example.com'))).toBe(true);
+  });
+
+  it('rejects cluster-internal and LAN targets (SSRF gate)', () => {
+    expect(isError(validateImportUrl('http://localhost:9000/api'))).toBe(true);
+    expect(isError(validateImportUrl('http://127.0.0.1/'))).toBe(true);
+    expect(isError(validateImportUrl('http://10.43.0.1/'))).toBe(true);
+    expect(isError(validateImportUrl('http://192.168.1.61/'))).toBe(true);
+    expect(isError(validateImportUrl('http://172.16.5.4/'))).toBe(true);
+    expect(isError(validateImportUrl('http://169.254.169.254/latest/meta-data'))).toBe(true);
+    expect(isError(validateImportUrl('http://mealie-postgresql.mealie.svc.cluster.local:5432'))).toBe(true);
+    expect(isError(validateImportUrl('http://qnap.local/'))).toBe(true);
+    expect(isError(validateImportUrl('https://pihole.lab.mtgibbs.dev/admin'))).toBe(true);
+    expect(isError(validateImportUrl('http://[::1]/'))).toBe(true);
+  });
+
+  it('rejects malformed and oversized input', () => {
+    expect(isError(validateImportUrl('not a url'))).toBe(true);
+    expect(isError(validateImportUrl(''))).toBe(true);
+    expect(isError(validateImportUrl(undefined))).toBe(true);
+    expect(isError(validateImportUrl(42))).toBe(true);
+    expect(isError(validateImportUrl(`https://example.com/${'a'.repeat(2100)}`))).toBe(true);
+  });
+
+  it('does not block public 172.x addresses outside 172.16/12', () => {
+    expect(validateImportUrl('http://172.32.0.1/')).toBeInstanceOf(URL);
+  });
+});
+
+describe('mealie slug validation', () => {
+  it('accepts normal slugs', () => {
+    expect(validateSlug('grandmas-chicken-soup')).toBe('grandmas-chicken-soup');
+    expect(validateSlug('recipe-123')).toBe('recipe-123');
+  });
+
+  it('rejects path traversal and injection shapes', () => {
+    expect(isError(validateSlug('../admin'))).toBe(true);
+    expect(isError(validateSlug('a/b'))).toBe(true);
+    expect(isError(validateSlug('a?x=1'))).toBe(true);
+    expect(isError(validateSlug(''))).toBe(true);
+    expect(isError(validateSlug(undefined))).toBe(true);
+    expect(isError(validateSlug('a'.repeat(300)))).toBe(true);
+  });
+});

--- a/src/__tests__/mealie.test.ts
+++ b/src/__tests__/mealie.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateImportUrl, validateSlug } from '../tools/mealie.js';
+import { validateImportUrl, validateSlug, beginImport, endImport } from '../tools/mealie.js';
 
 function isError(v: unknown): boolean {
   return typeof v === 'object' && v !== null && (v as { error?: boolean }).error === true;
@@ -40,6 +40,24 @@ describe('mealie import URL gate', () => {
 
   it('does not block public 172.x addresses outside 172.16/12', () => {
     expect(validateImportUrl('http://172.32.0.1/')).toBeInstanceOf(URL);
+  });
+});
+
+describe('mealie import active-run guard', () => {
+  it('blocks a second import of the same URL while one is in flight', () => {
+    const key = 'https://example.com/soup';
+    expect(beginImport(key)).toBe(true);
+    expect(beginImport(key)).toBe(false); // overlap refused
+    endImport(key);
+    expect(beginImport(key)).toBe(true); // released after completion
+    endImport(key);
+  });
+
+  it('allows different URLs to import concurrently', () => {
+    expect(beginImport('https://example.com/a')).toBe(true);
+    expect(beginImport('https://example.com/b')).toBe(true);
+    endImport('https://example.com/a');
+    endImport('https://example.com/b');
   });
 });
 

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -62,10 +62,15 @@ describe('tool registry', () => {
     // Arr shared tools
     expect(toolNames).toContain('get_quality_profile');
     expect(toolNames).toContain('reject_and_search');
+    // Mealie tools
+    expect(toolNames).toContain('get_mealie_status');
+    expect(toolNames).toContain('search_mealie_recipes');
+    expect(toolNames).toContain('get_mealie_recipe');
+    expect(toolNames).toContain('import_mealie_recipe_url');
   });
 
   it('has the expected total tool count', () => {
-    expect(tools).toHaveLength(45);
+    expect(tools).toHaveLength(49);
   });
 
   it('has no duplicate tool names', () => {

--- a/src/clients/mealie.ts
+++ b/src/clients/mealie.ts
@@ -1,0 +1,127 @@
+// Mealie API client
+// API docs: https://docs.mealie.io/api/redoc/ (endpoints verified against v3.20.1 source)
+
+const MEALIE_URL = process.env.MEALIE_URL || 'http://mealie.mealie.svc.cluster.local:9000';
+const MEALIE_API_TOKEN = process.env.MEALIE_API_TOKEN;
+const MEALIE_PUBLIC_URL = process.env.MEALIE_PUBLIC_URL || 'https://recipes.lab.mtgibbs.dev';
+const MEALIE_GROUP_SLUG = process.env.MEALIE_GROUP_SLUG || 'home';
+
+// Web-UI link for a recipe (v3 routes are group-scoped)
+export function recipeUrl(slug: string): string {
+  return `${MEALIE_PUBLIC_URL}/g/${MEALIE_GROUP_SLUG}/r/${slug}`;
+}
+
+async function mealieFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  if (!MEALIE_API_TOKEN) {
+    throw new Error('MEALIE_API_TOKEN environment variable not set');
+  }
+
+  const url = `${MEALIE_URL}/api${path}`;
+  const headers = {
+    Authorization: `Bearer ${MEALIE_API_TOKEN}`,
+    'Content-Type': 'application/json',
+    ...options.headers,
+  };
+
+  const response = await fetch(url, { ...options, headers });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Mealie API error: ${response.status} ${response.statusText}${body ? ` — ${body.slice(0, 300)}` : ''}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+// Types based on Mealie API (summary fields only — full Recipe is much larger)
+
+export interface AppAbout {
+  production: boolean;
+  version: string;
+  demoStatus: boolean;
+  allowSignup: boolean;
+}
+
+export interface AppStatistics {
+  totalRecipes: number;
+  totalUsers: number;
+  totalCategories: number;
+  totalTags: number;
+  totalTools: number;
+}
+
+export interface RecipeSummary {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string;
+  totalTime?: string | null;
+  recipeServings?: number;
+  rating?: number | null;
+  orgURL?: string | null;
+  dateAdded?: string;
+  recipeCategory?: { name: string }[];
+  tags?: { name: string }[];
+}
+
+export interface PaginatedRecipes {
+  page: number;
+  total: number;
+  totalPages: number;
+  items: RecipeSummary[];
+}
+
+export interface RecipeIngredient {
+  quantity?: number | null;
+  unit?: { name: string } | null;
+  food?: { name: string } | null;
+  note?: string | null;
+  display?: string;
+}
+
+export interface RecipeInstruction {
+  title?: string;
+  text: string;
+}
+
+export interface Recipe extends RecipeSummary {
+  recipeIngredient: RecipeIngredient[];
+  recipeInstructions: RecipeInstruction[];
+  recipeYield?: string | null;
+  prepTime?: string | null;
+  performTime?: string | null;
+  notes?: { title?: string; text: string }[];
+}
+
+export async function getAbout(): Promise<AppAbout> {
+  return mealieFetch<AppAbout>('/app/about');
+}
+
+export async function getStatistics(): Promise<AppStatistics> {
+  return mealieFetch<AppStatistics>('/admin/about/statistics');
+}
+
+export async function searchRecipes(search: string | undefined, page: number, perPage: number): Promise<PaginatedRecipes> {
+  const params = new URLSearchParams({
+    page: String(page),
+    perPage: String(perPage),
+    orderBy: 'created_at',
+    orderDirection: 'desc',
+  });
+  if (search) {
+    params.set('search', search);
+  }
+  return mealieFetch<PaginatedRecipes>(`/recipes?${params.toString()}`);
+}
+
+export async function getRecipe(slug: string): Promise<Recipe> {
+  return mealieFetch<Recipe>(`/recipes/${encodeURIComponent(slug)}`);
+}
+
+// Returns the slug of the created recipe
+export async function importRecipeFromUrl(url: string, includeTags: boolean): Promise<string> {
+  return mealieFetch<string>('/recipes/create/url', {
+    method: 'POST',
+    body: JSON.stringify({ url, includeTags }),
+  });
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -16,6 +16,7 @@ import { sonarrTools } from './sonarr.js';
 import { radarrTools } from './radarr.js';
 import { sabnzbdTools } from './sabnzbd.js';
 import { arrSharedTools } from './arr-shared.js';
+import { mealieTools } from './mealie.js';
 
 export interface Tool {
   name: string;
@@ -47,6 +48,7 @@ export const tools: Tool[] = [
   ...radarrTools,
   ...sabnzbdTools,
   ...arrSharedTools,
+  ...mealieTools,
 ];
 
 const toolMap = new Map(tools.map((t) => [t.name, t]));

--- a/src/tools/mealie.ts
+++ b/src/tools/mealie.ts
@@ -36,6 +36,22 @@ export function validateImportUrl(raw: unknown): URL | ToolError {
   return url;
 }
 
+// Active-run guard: one in-flight import per normalized URL, so overlapping
+// calls can't race Mealie into duplicate recipes.
+const activeImports = new Set<string>();
+
+export function beginImport(key: string): boolean {
+  if (activeImports.has(key)) {
+    return false;
+  }
+  activeImports.add(key);
+  return true;
+}
+
+export function endImport(key: string): void {
+  activeImports.delete(key);
+}
+
 export function validateSlug(raw: unknown): string | ToolError {
   if (typeof raw !== 'string' || raw.length === 0 || raw.length > 256) {
     return validationError('slug must be a non-empty string (max 256 chars)');
@@ -197,8 +213,16 @@ const importMealieRecipeUrl: Tool = {
     }
     const includeTags = params.includeTags !== false;
 
+    const importKey = url.toString();
+    if (!beginImport(importKey)) {
+      return {
+        error: true,
+        code: 'IMPORT_IN_PROGRESS',
+        message: `An import for ${importKey} is already running — wait for it to finish instead of retrying.`,
+      };
+    }
     try {
-      const slug = await mealie.importRecipeFromUrl(url.toString(), includeTags);
+      const slug = await mealie.importRecipeFromUrl(importKey, includeTags);
       return {
         imported: true,
         slug,
@@ -207,6 +231,8 @@ const importMealieRecipeUrl: Tool = {
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown Mealie error';
       return { error: true, code: 'MEALIE_ERROR', message };
+    } finally {
+      endImport(importKey);
     }
   },
 };

--- a/src/tools/mealie.ts
+++ b/src/tools/mealie.ts
@@ -1,5 +1,50 @@
 import type { Tool } from './index.js';
 import * as mealie from '../clients/mealie.js';
+import { validationError, type ToolError } from '../utils/errors.js';
+
+const PRIVATE_IPV4 =
+  /^(127\.|10\.|192\.168\.|169\.254\.|172\.(1[6-9]|2\d|3[01])\.|0\.)/;
+
+// Gate for the import sink: Mealie's server fetches the URL we hand it, so
+// refuse anything that could point it at cluster-internal or LAN targets.
+export function validateImportUrl(raw: unknown): URL | ToolError {
+  if (typeof raw !== 'string' || raw.length === 0 || raw.length > 2048) {
+    return validationError('url must be a non-empty string (max 2048 chars)');
+  }
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return validationError(`url is not a valid URL: ${raw}`);
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return validationError(`url must be http(s), got ${url.protocol}`);
+  }
+  const host = url.hostname.toLowerCase();
+  if (
+    host === 'localhost' ||
+    host.startsWith('[') || // IPv6 literal
+    host.includes(':') ||
+    host.endsWith('.local') ||
+    host.endsWith('.internal') ||
+    host.endsWith('.cluster.local') ||
+    host.endsWith('.lab.mtgibbs.dev') ||
+    PRIVATE_IPV4.test(host)
+  ) {
+    return validationError(`url host '${host}' is internal/private — recipe imports must target public sites`);
+  }
+  return url;
+}
+
+export function validateSlug(raw: unknown): string | ToolError {
+  if (typeof raw !== 'string' || raw.length === 0 || raw.length > 256) {
+    return validationError('slug must be a non-empty string (max 256 chars)');
+  }
+  if (!/^[a-z0-9][a-z0-9-]*$/i.test(raw)) {
+    return validationError(`slug '${raw}' is not a valid Mealie slug`);
+  }
+  return raw;
+}
 
 interface RecipeSummaryOut {
   slug: string;
@@ -103,7 +148,10 @@ const getMealieRecipe: Tool = {
     required: ['slug'],
   },
   handler: async (params) => {
-    const slug = params.slug as string;
+    const slug = validateSlug(params.slug);
+    if (typeof slug !== 'string') {
+      return slug;
+    }
 
     try {
       const recipe = await mealie.getRecipe(slug);
@@ -143,11 +191,14 @@ const importMealieRecipeUrl: Tool = {
     required: ['url'],
   },
   handler: async (params) => {
-    const url = params.url as string;
+    const url = validateImportUrl(params.url);
+    if (!(url instanceof URL)) {
+      return url;
+    }
     const includeTags = params.includeTags !== false;
 
     try {
-      const slug = await mealie.importRecipeFromUrl(url, includeTags);
+      const slug = await mealie.importRecipeFromUrl(url.toString(), includeTags);
       return {
         imported: true,
         slug,

--- a/src/tools/mealie.ts
+++ b/src/tools/mealie.ts
@@ -1,0 +1,163 @@
+import type { Tool } from './index.js';
+import * as mealie from '../clients/mealie.js';
+
+interface RecipeSummaryOut {
+  slug: string;
+  name: string;
+  description?: string;
+  totalTime?: string;
+  servings?: number;
+  rating?: number;
+  sourceUrl?: string;
+  dateAdded?: string;
+  categories?: string[];
+  tags?: string[];
+}
+
+function summarizeRecipe(r: mealie.RecipeSummary): RecipeSummaryOut {
+  return {
+    slug: r.slug,
+    name: r.name,
+    description: r.description || undefined,
+    totalTime: r.totalTime || undefined,
+    servings: r.recipeServings || undefined,
+    rating: r.rating ?? undefined,
+    sourceUrl: r.orgURL || undefined,
+    dateAdded: r.dateAdded,
+    categories: r.recipeCategory?.map((c) => c.name),
+    tags: r.tags?.map((t) => t.name),
+  };
+}
+
+const getMealieStatus: Tool = {
+  name: 'get_mealie_status',
+  description:
+    'Get Mealie recipe manager status: version, signup state, and library statistics (recipe/user/category/tag counts).',
+  inputSchema: {
+    type: 'object',
+    properties: {},
+  },
+  handler: async () => {
+    try {
+      const about = await mealie.getAbout();
+      let statistics: mealie.AppStatistics | { error: string };
+      try {
+        statistics = await mealie.getStatistics();
+      } catch (error) {
+        statistics = { error: error instanceof Error ? error.message : 'statistics unavailable' };
+      }
+      return {
+        version: about.version,
+        production: about.production,
+        allowSignup: about.allowSignup,
+        statistics,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown Mealie error';
+      return { error: true, code: 'MEALIE_ERROR', message };
+    }
+  },
+};
+
+const searchMealieRecipes: Tool = {
+  name: 'search_mealie_recipes',
+  description:
+    'Search recipes in Mealie by text (name, ingredients, description). Omit search to list the most recently added recipes.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      search: { type: 'string', description: 'Search text (optional — omit to list recent recipes)' },
+      page: { type: 'number', description: 'Page number (default: 1)', default: 1 },
+      perPage: { type: 'number', description: 'Results per page (default: 10, max: 50)', default: 10 },
+    },
+  },
+  handler: async (params) => {
+    const search = params.search as string | undefined;
+    const page = Math.max((params.page as number) || 1, 1);
+    const perPage = Math.min(Math.max((params.perPage as number) || 10, 1), 50);
+
+    try {
+      const results = await mealie.searchRecipes(search, page, perPage);
+      return {
+        total: results.total,
+        page: results.page,
+        totalPages: results.totalPages,
+        recipes: results.items.map(summarizeRecipe),
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown Mealie error';
+      return { error: true, code: 'MEALIE_ERROR', message };
+    }
+  },
+};
+
+const getMealieRecipe: Tool = {
+  name: 'get_mealie_recipe',
+  description:
+    'Get a full recipe from Mealie by slug, including ingredients, instructions, times, and notes.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      slug: { type: 'string', description: 'Recipe slug (from search_mealie_recipes or an import result)' },
+    },
+    required: ['slug'],
+  },
+  handler: async (params) => {
+    const slug = params.slug as string;
+
+    try {
+      const recipe = await mealie.getRecipe(slug);
+      return {
+        ...summarizeRecipe(recipe),
+        yield: recipe.recipeYield || undefined,
+        prepTime: recipe.prepTime || undefined,
+        cookTime: recipe.performTime || undefined,
+        ingredients: recipe.recipeIngredient.map(
+          (i) => i.display || [i.quantity, i.unit?.name, i.food?.name, i.note].filter(Boolean).join(' ')
+        ),
+        instructions: recipe.recipeInstructions.map((s, idx) => `${idx + 1}. ${s.title ? `${s.title}: ` : ''}${s.text}`),
+        notes: recipe.notes?.map((n) => (n.title ? `${n.title}: ${n.text}` : n.text)),
+        url: mealie.recipeUrl(recipe.slug),
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown Mealie error';
+      return { error: true, code: 'MEALIE_ERROR', message };
+    }
+  },
+};
+
+const importMealieRecipeUrl: Tool = {
+  name: 'import_mealie_recipe_url',
+  description:
+    'Import a recipe into Mealie from a URL (the recipe-scrapers/schema.org path — no AI required). Returns the created recipe slug. Fails cleanly on sites without structured recipe data.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: 'Recipe page URL to import' },
+      includeTags: {
+        type: 'boolean',
+        description: 'Import the site’s keywords as Mealie tags (default: true)',
+        default: true,
+      },
+    },
+    required: ['url'],
+  },
+  handler: async (params) => {
+    const url = params.url as string;
+    const includeTags = params.includeTags !== false;
+
+    try {
+      const slug = await mealie.importRecipeFromUrl(url, includeTags);
+      return {
+        imported: true,
+        slug,
+        url: mealie.recipeUrl(slug),
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown Mealie error';
+      return { error: true, code: 'MEALIE_ERROR', message };
+    }
+  },
+};
+
+export const mealieTools: Tool[] = [getMealieStatus, searchMealieRecipes, getMealieRecipe, importMealieRecipeUrl];


### PR DESCRIPTION
## Summary

New service integration for the Mealie recipe manager (deployed at recipes.lab.mtgibbs.dev, pi-cluster #49):

- `src/clients/mealie.ts` — Bearer-token client, endpoints verified against Mealie v3.20.1 source
- `get_mealie_status` — version + library statistics (statistics degrade gracefully if the token isn't admin)
- `search_mealie_recipes` — text search / recent list, paginated
- `get_mealie_recipe` — full recipe (ingredients, instructions, notes) + web link
- `import_mealie_recipe_url` — the recipe-scrapers path (no AI), returns slug + web link

Env: `MEALIE_API_TOKEN` (required), `MEALIE_URL`, `MEALIE_PUBLIC_URL`, `MEALIE_GROUP_SLUG` (defaults). README tables updated.

Deploy side (pi-cluster repo, follow-up PR): ExternalSecret key `mealie/api-token` + env wiring on the mcp-homelab Deployment. IUA auto-rolls the image once released.

## Testing
- `tsc --noEmit` + eslint clean locally (vitest requires esbuild exec, blocked in this sandbox — CI runs it)
- No existing tests touch these files; tools follow the sonarr/radarr client+tool pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)