### PR TITLE
feat: structured ingredient parsing for Mealie imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The server is designed to be deployed as a Pod in your cluster.
 | **Movies (Radarr)** | `get_radarr_queue`, `get_radarr_history`, `search_radarr_movie` |
 | **Downloads (SABnzbd)** | `get_sabnzbd_queue`, `get_sabnzbd_history`, `retry_sabnzbd_download`, `pause_resume_sabnzbd` |
 | **Arr Shared** | `get_quality_profile`, `reject_and_search` |
-| **Recipes (Mealie)** | `get_mealie_status`, `search_mealie_recipes`, `get_mealie_recipe`, `import_mealie_recipe_url` |
+| **Recipes (Mealie)** | `get_mealie_status`, `search_mealie_recipes`, `get_mealie_recipe`, `import_mealie_recipe_url`, `parse_mealie_recipe_ingredients` |
 | **Backups** | `get_backup_status`, `trigger_backup`, `get_cronjob_details`, `get_job_logs` |
 | **Secrets** | `get_secrets_status`, `refresh_secret` |
 | **Storage** | `get_pvcs` |

--- a/src/__tests__/mealie.test.ts
+++ b/src/__tests__/mealie.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { validateImportUrl, validateSlug, validateParser, beginImport, endImport } from '../tools/mealie.js';
+import {
+  validateImportUrl,
+  validateSlug,
+  validateParser,
+  beginImport,
+  endImport,
+  parseGuardKey,
+} from '../tools/mealie.js';
 
 function isError(v: unknown): boolean {
   return typeof v === 'object' && v !== null && (v as { error?: boolean }).error === true;
@@ -58,6 +65,22 @@ describe('mealie import active-run guard', () => {
     expect(beginImport('https://example.com/b')).toBe(true);
     endImport('https://example.com/a');
     endImport('https://example.com/b');
+  });
+
+  it('parse operations on the same slug share one guard key regardless of caller', () => {
+    // Both the standalone parse tool and the import-embedded parse acquire
+    // parseGuardKey(slug), so they can never race the same recipe.
+    const key = parseGuardKey('gyudon');
+    expect(beginImport(key)).toBe(true);
+    expect(beginImport(parseGuardKey('gyudon'))).toBe(false); // blocked
+    expect(beginImport(parseGuardKey('other-recipe'))).toBe(true); // independent
+    endImport(key);
+    endImport(parseGuardKey('other-recipe'));
+  });
+
+  it('parse guard keys never collide with import URL keys', () => {
+    expect(parseGuardKey('gyudon')).not.toBe('gyudon');
+    expect(parseGuardKey('gyudon').startsWith('parse:')).toBe(true);
   });
 });
 

--- a/src/__tests__/mealie.test.ts
+++ b/src/__tests__/mealie.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateImportUrl, validateSlug, beginImport, endImport } from '../tools/mealie.js';
+import { validateImportUrl, validateSlug, validateParser, beginImport, endImport } from '../tools/mealie.js';
 
 function isError(v: unknown): boolean {
   return typeof v === 'object' && v !== null && (v as { error?: boolean }).error === true;
@@ -58,6 +58,25 @@ describe('mealie import active-run guard', () => {
     expect(beginImport('https://example.com/b')).toBe(true);
     endImport('https://example.com/a');
     endImport('https://example.com/b');
+  });
+});
+
+describe('mealie parser validation', () => {
+  it('defaults to nlp when omitted', () => {
+    expect(validateParser(undefined)).toBe('nlp');
+    expect(validateParser(null)).toBe('nlp');
+  });
+
+  it('accepts known parsers', () => {
+    expect(validateParser('nlp')).toBe('nlp');
+    expect(validateParser('brute')).toBe('brute');
+    expect(validateParser('openai')).toBe('openai');
+  });
+
+  it('rejects unknown parsers', () => {
+    expect(isError(validateParser('gpt4'))).toBe(true);
+    expect(isError(validateParser(42))).toBe(true);
+    expect(isError(validateParser(''))).toBe(true);
   });
 });
 

--- a/src/__tests__/mealie.test.ts
+++ b/src/__tests__/mealie.test.ts
@@ -6,6 +6,7 @@ import {
   beginImport,
   endImport,
   parseGuardKey,
+  isRecipeParseEligible,
 } from '../tools/mealie.js';
 
 function isError(v: unknown): boolean {
@@ -81,6 +82,18 @@ describe('mealie import active-run guard', () => {
   it('parse guard keys never collide with import URL keys', () => {
     expect(parseGuardKey('gyudon')).not.toBe('gyudon');
     expect(parseGuardKey('gyudon').startsWith('parse:')).toBe(true);
+  });
+});
+
+describe('mealie parse scope gate', () => {
+  it('admits unstructured (machine-imported) recipes', () => {
+    expect(isRecipeParseEligible({ disableAmount: true })).toBe(true);
+    expect(isRecipeParseEligible({})).toBe(true);
+    expect(isRecipeParseEligible(undefined)).toBe(true);
+  });
+
+  it('refuses recipes that already have structured ingredients — no override', () => {
+    expect(isRecipeParseEligible({ disableAmount: false })).toBe(false);
   });
 });
 

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -67,10 +67,11 @@ describe('tool registry', () => {
     expect(toolNames).toContain('search_mealie_recipes');
     expect(toolNames).toContain('get_mealie_recipe');
     expect(toolNames).toContain('import_mealie_recipe_url');
+    expect(toolNames).toContain('parse_mealie_recipe_ingredients');
   });
 
   it('has the expected total tool count', () => {
-    expect(tools).toHaveLength(49);
+    expect(tools).toHaveLength(50);
   });
 
   it('has no duplicate tool names', () => {

--- a/src/clients/mealie.ts
+++ b/src/clients/mealie.ts
@@ -125,3 +125,41 @@ export async function importRecipeFromUrl(url: string, includeTags: boolean): Pr
     body: JSON.stringify({ url, includeTags }),
   });
 }
+
+// Ingredient parsing (POST /api/parser/ingredients). The parser matches
+// foods/units against the group's existing records; unmatched ones come back
+// as create-by-name objects, which the recipe PUT accepts and creates.
+
+export type IngredientParser = 'nlp' | 'brute' | 'openai';
+
+export interface ParsedIngredient {
+  input?: string | null;
+  confidence?: { average?: number | null };
+  ingredient: {
+    quantity?: number | null;
+    unit?: { id?: string; name: string } | null;
+    food?: { id?: string; name: string } | null;
+    note?: string | null;
+    display?: string;
+  };
+}
+
+export async function parseIngredients(parser: IngredientParser, ingredients: string[]): Promise<ParsedIngredient[]> {
+  return mealieFetch<ParsedIngredient[]>('/parser/ingredients', {
+    method: 'POST',
+    body: JSON.stringify({ parser, ingredients }),
+  });
+}
+
+// Raw recipe JSON round-trip for structured updates. The full Recipe payload
+// is much larger than our trimmed Recipe interface, so treat it as opaque.
+export async function getRecipeRaw(slug: string): Promise<Record<string, unknown>> {
+  return mealieFetch<Record<string, unknown>>(`/recipes/${encodeURIComponent(slug)}`);
+}
+
+export async function updateRecipeRaw(slug: string, recipe: Record<string, unknown>): Promise<Record<string, unknown>> {
+  return mealieFetch<Record<string, unknown>>(`/recipes/${encodeURIComponent(slug)}`, {
+    method: 'PUT',
+    body: JSON.stringify(recipe),
+  });
+}

--- a/src/tools/mealie.ts
+++ b/src/tools/mealie.ts
@@ -217,21 +217,26 @@ export function parseGuardKey(slug: string): string {
   return `parse:${slug}`;
 }
 
+// Scope gate for the parse mutation (same role as isDeploymentAllowed for
+// restart_deployment): parsing may ONLY target recipes that are still
+// unstructured — settings.disableAmount !== false, i.e. machine-imported and
+// never parsed. Recipes with structured (possibly hand-curated) ingredients
+// are refused unconditionally; there is no caller override. This closes the
+// tool's reachable set to unstructured→structured transitions only.
+export function isRecipeParseEligible(settings: Record<string, unknown> | undefined): boolean {
+  return (settings?.disableAmount ?? true) !== false;
+}
+
 // Parse a recipe's ingredient lines into structured quantity/unit/food and
 // write them back. Also flips settings.disableAmount off — imports set it
 // true, which is why imported ingredients render as plain text.
 //
-// Write scope (mutation gate): the PUT only replaces `recipeIngredient` —
-// derived exclusively from the recipe's OWN existing ingredient lines — and
-// `settings.disableAmount`. No caller-supplied content reaches the write;
-// `parser` merely selects Mealie's parsing backend. Recipes that already
-// have structured ingredients are refused unless `force` is set, so a
-// hand-curated recipe can't be silently clobbered.
-async function parseAndApplyIngredients(
-  slug: string,
-  parser: mealie.IngredientParser,
-  force: boolean
-): Promise<ParseOutcome> {
+// Write scope: the PUT only replaces `recipeIngredient` — derived exclusively
+// from the recipe's OWN existing ingredient lines — and `settings.disableAmount`.
+// No caller-supplied content reaches the write; `parser` merely selects
+// Mealie's parsing backend. The isRecipeParseEligible gate runs BEFORE any
+// mutation: structured recipes are refused with no override.
+async function parseAndApplyIngredients(slug: string, parser: mealie.IngredientParser): Promise<ParseOutcome> {
   const guardKey = parseGuardKey(slug);
   if (!beginImport(guardKey)) {
     return { parsed: false, parser, error: `a parse for '${slug}' is already running — wait for it to finish` };
@@ -239,11 +244,11 @@ async function parseAndApplyIngredients(
   try {
     const recipe = await mealie.getRecipeRaw(slug);
     const settings = (recipe.settings as Record<string, unknown> | undefined) ?? {};
-    if (settings.disableAmount === false && !force) {
+    if (!isRecipeParseEligible(settings)) {
       return {
         parsed: false,
         parser,
-        error: `'${slug}' already has structured ingredients — pass force: true to re-parse and overwrite them`,
+        error: `'${slug}' already has structured ingredients — parsing is not allowed on structured recipes (edit them in the Mealie UI instead)`,
       };
     }
     const existing = (recipe.recipeIngredient as Record<string, unknown>[] | undefined) ?? [];
@@ -345,9 +350,9 @@ const importMealieRecipeUrl: Tool = {
     try {
       const slug = await mealie.importRecipeFromUrl(importKey, includeTags);
       // Embedded parse writes ONLY to the slug this import just created —
-      // never a pre-existing recipe (fresh imports always have
-      // disableAmount=true, so the no-force overwrite gate stays intact).
-      const parse = shouldParse ? await parseAndApplyIngredients(slug, parser, false) : undefined;
+      // never a pre-existing recipe (fresh imports are always unstructured,
+      // so the isRecipeParseEligible gate admits them and nothing else).
+      const parse = shouldParse ? await parseAndApplyIngredients(slug, parser) : undefined;
       return {
         imported: true,
         slug,
@@ -366,22 +371,16 @@ const importMealieRecipeUrl: Tool = {
 const parseMealieRecipeIngredients: Tool = {
   name: 'parse_mealie_recipe_ingredients',
   description:
-    'Parse an existing Mealie recipe’s ingredient lines into structured quantity/unit/food and save them back (enables scaling and shopping-list merging). Use on recipes imported before structured parsing existed, or to re-parse with a different parser.',
+    'Parse an unstructured Mealie recipe’s ingredient lines into structured quantity/unit/food and save them back (enables scaling and shopping-list merging). Only targets recipes that have never been parsed (machine imports); recipes with structured ingredients are refused to protect hand-curated data.',
   inputSchema: {
     type: 'object',
     properties: {
-      slug: { type: 'string', description: 'Recipe slug to parse' },
+      slug: { type: 'string', description: 'Recipe slug to parse (must be an unstructured/machine-imported recipe)' },
       parser: {
         type: 'string',
         enum: ['nlp', 'brute', 'openai'],
         description: 'Ingredient parser: nlp (built-in, fast, default), brute, or openai (group AI provider)',
         default: 'nlp',
-      },
-      force: {
-        type: 'boolean',
-        description:
-          'Required to re-parse a recipe that already has structured ingredients (overwrites them; original text lines are preserved in originalText). Default: false',
-        default: false,
       },
     },
     required: ['slug'],
@@ -396,7 +395,7 @@ const parseMealieRecipeIngredients: Tool = {
       return parser;
     }
 
-    const outcome = await parseAndApplyIngredients(slug, parser, params.force === true);
+    const outcome = await parseAndApplyIngredients(slug, parser);
     return { slug, url: mealie.recipeUrl(slug), ...outcome };
   },
 };

--- a/src/tools/mealie.ts
+++ b/src/tools/mealie.ts
@@ -190,10 +190,84 @@ const getMealieRecipe: Tool = {
   },
 };
 
+const PARSERS = ['nlp', 'brute', 'openai'] as const;
+
+export function validateParser(raw: unknown): mealie.IngredientParser | ToolError {
+  if (raw === undefined || raw === null) {
+    return 'nlp';
+  }
+  if (typeof raw !== 'string' || !PARSERS.includes(raw as mealie.IngredientParser)) {
+    return validationError(`parser must be one of ${PARSERS.join(', ')}`);
+  }
+  return raw as mealie.IngredientParser;
+}
+
+interface ParseOutcome {
+  parsed: boolean;
+  parser?: mealie.IngredientParser;
+  ingredients?: { input: string; quantity?: number | null; unit?: string; food?: string; note?: string }[];
+  matchedFoods?: number;
+  error?: string;
+}
+
+// Parse a recipe's ingredient lines into structured quantity/unit/food and
+// write them back. Also flips settings.disableAmount off — imports set it
+// true, which is why imported ingredients render as plain text.
+async function parseAndApplyIngredients(slug: string, parser: mealie.IngredientParser): Promise<ParseOutcome> {
+  try {
+    const recipe = await mealie.getRecipeRaw(slug);
+    const existing = (recipe.recipeIngredient as Record<string, unknown>[] | undefined) ?? [];
+    if (existing.length === 0) {
+      return { parsed: false, parser, error: 'recipe has no ingredient lines to parse' };
+    }
+    if (existing.length > 100) {
+      return { parsed: false, parser, error: `refusing to parse ${existing.length} ingredient lines (max 100)` };
+    }
+
+    const lines = existing.map((i) =>
+      String(i.originalText || i.display || i.note || '').trim()
+    );
+    const parsedResults = await mealie.parseIngredients(
+      parser,
+      lines.map((line) => line.replace(/^[-*•]\s*/, ''))
+    );
+    if (parsedResults.length !== lines.length) {
+      return { parsed: false, parser, error: `parser returned ${parsedResults.length} results for ${lines.length} lines` };
+    }
+
+    recipe.recipeIngredient = parsedResults.map((p, idx) => ({
+      ...p.ingredient,
+      originalText: lines[idx],
+    }));
+    const settings = (recipe.settings as Record<string, unknown> | undefined) ?? {};
+    settings.disableAmount = false;
+    recipe.settings = settings;
+
+    await mealie.updateRecipeRaw(slug, recipe);
+
+    return {
+      parsed: true,
+      parser,
+      matchedFoods: parsedResults.filter((p) => p.ingredient.food?.id).length,
+      ingredients: parsedResults.map((p, idx) => ({
+        input: lines[idx],
+        quantity: p.ingredient.quantity,
+        unit: p.ingredient.unit?.name,
+        food: p.ingredient.food?.name,
+        note: p.ingredient.note || undefined,
+      })),
+    };
+  } catch (error) {
+    // The recipe itself is intact either way — report the parse failure
+    // rather than failing the caller's import.
+    return { parsed: false, parser, error: error instanceof Error ? error.message : 'Unknown Mealie error' };
+  }
+}
+
 const importMealieRecipeUrl: Tool = {
   name: 'import_mealie_recipe_url',
   description:
-    'Import a recipe into Mealie from a URL (the recipe-scrapers/schema.org path — no AI required). Returns the created recipe slug. Fails cleanly on sites without structured recipe data.',
+    'Import a recipe into Mealie from a URL (the recipe-scrapers/schema.org path — no AI required). By default the imported ingredient lines are then parsed into structured quantity/unit/food (enables scaling + shopping lists). Returns the created recipe slug plus the parse outcome. Fails cleanly on sites without structured recipe data.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -203,6 +277,17 @@ const importMealieRecipeUrl: Tool = {
         description: 'Import the site’s keywords as Mealie tags (default: true)',
         default: true,
       },
+      parseIngredients: {
+        type: 'boolean',
+        description: 'Parse ingredient lines into structured quantity/unit/food after import (default: true)',
+        default: true,
+      },
+      parser: {
+        type: 'string',
+        enum: ['nlp', 'brute', 'openai'],
+        description: 'Ingredient parser: nlp (built-in, fast, default), brute, or openai (group AI provider)',
+        default: 'nlp',
+      },
     },
     required: ['url'],
   },
@@ -211,7 +296,12 @@ const importMealieRecipeUrl: Tool = {
     if (!(url instanceof URL)) {
       return url;
     }
+    const parser = validateParser(params.parser);
+    if (typeof parser !== 'string') {
+      return parser;
+    }
     const includeTags = params.includeTags !== false;
+    const shouldParse = params.parseIngredients !== false;
 
     const importKey = url.toString();
     if (!beginImport(importKey)) {
@@ -223,10 +313,12 @@ const importMealieRecipeUrl: Tool = {
     }
     try {
       const slug = await mealie.importRecipeFromUrl(importKey, includeTags);
+      const parse = shouldParse ? await parseAndApplyIngredients(slug, parser) : undefined;
       return {
         imported: true,
         slug,
         url: mealie.recipeUrl(slug),
+        parse,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown Mealie error';
@@ -237,4 +329,54 @@ const importMealieRecipeUrl: Tool = {
   },
 };
 
-export const mealieTools: Tool[] = [getMealieStatus, searchMealieRecipes, getMealieRecipe, importMealieRecipeUrl];
+const parseMealieRecipeIngredients: Tool = {
+  name: 'parse_mealie_recipe_ingredients',
+  description:
+    'Parse an existing Mealie recipe’s ingredient lines into structured quantity/unit/food and save them back (enables scaling and shopping-list merging). Use on recipes imported before structured parsing existed, or to re-parse with a different parser.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      slug: { type: 'string', description: 'Recipe slug to parse' },
+      parser: {
+        type: 'string',
+        enum: ['nlp', 'brute', 'openai'],
+        description: 'Ingredient parser: nlp (built-in, fast, default), brute, or openai (group AI provider)',
+        default: 'nlp',
+      },
+    },
+    required: ['slug'],
+  },
+  handler: async (params) => {
+    const slug = validateSlug(params.slug);
+    if (typeof slug !== 'string') {
+      return slug;
+    }
+    const parser = validateParser(params.parser);
+    if (typeof parser !== 'string') {
+      return parser;
+    }
+
+    const parseKey = `parse:${slug}`;
+    if (!beginImport(parseKey)) {
+      return {
+        error: true,
+        code: 'PARSE_IN_PROGRESS',
+        message: `A parse for '${slug}' is already running — wait for it to finish instead of retrying.`,
+      };
+    }
+    try {
+      const outcome = await parseAndApplyIngredients(slug, parser);
+      return { slug, url: mealie.recipeUrl(slug), ...outcome };
+    } finally {
+      endImport(parseKey);
+    }
+  },
+};
+
+export const mealieTools: Tool[] = [
+  getMealieStatus,
+  searchMealieRecipes,
+  getMealieRecipe,
+  importMealieRecipeUrl,
+  parseMealieRecipeIngredients,
+];

--- a/src/tools/mealie.ts
+++ b/src/tools/mealie.ts
@@ -210,12 +210,42 @@ interface ParseOutcome {
   error?: string;
 }
 
+// Single guard key for ALL ingredient-parse writes on a slug — used by both
+// the standalone parse tool and the parse embedded in URL import, so the two
+// paths can never race the same recipe's read-modify-write.
+export function parseGuardKey(slug: string): string {
+  return `parse:${slug}`;
+}
+
 // Parse a recipe's ingredient lines into structured quantity/unit/food and
 // write them back. Also flips settings.disableAmount off — imports set it
 // true, which is why imported ingredients render as plain text.
-async function parseAndApplyIngredients(slug: string, parser: mealie.IngredientParser): Promise<ParseOutcome> {
+//
+// Write scope (mutation gate): the PUT only replaces `recipeIngredient` —
+// derived exclusively from the recipe's OWN existing ingredient lines — and
+// `settings.disableAmount`. No caller-supplied content reaches the write;
+// `parser` merely selects Mealie's parsing backend. Recipes that already
+// have structured ingredients are refused unless `force` is set, so a
+// hand-curated recipe can't be silently clobbered.
+async function parseAndApplyIngredients(
+  slug: string,
+  parser: mealie.IngredientParser,
+  force: boolean
+): Promise<ParseOutcome> {
+  const guardKey = parseGuardKey(slug);
+  if (!beginImport(guardKey)) {
+    return { parsed: false, parser, error: `a parse for '${slug}' is already running — wait for it to finish` };
+  }
   try {
     const recipe = await mealie.getRecipeRaw(slug);
+    const settings = (recipe.settings as Record<string, unknown> | undefined) ?? {};
+    if (settings.disableAmount === false && !force) {
+      return {
+        parsed: false,
+        parser,
+        error: `'${slug}' already has structured ingredients — pass force: true to re-parse and overwrite them`,
+      };
+    }
     const existing = (recipe.recipeIngredient as Record<string, unknown>[] | undefined) ?? [];
     if (existing.length === 0) {
       return { parsed: false, parser, error: 'recipe has no ingredient lines to parse' };
@@ -239,7 +269,6 @@ async function parseAndApplyIngredients(slug: string, parser: mealie.IngredientP
       ...p.ingredient,
       originalText: lines[idx],
     }));
-    const settings = (recipe.settings as Record<string, unknown> | undefined) ?? {};
     settings.disableAmount = false;
     recipe.settings = settings;
 
@@ -261,6 +290,8 @@ async function parseAndApplyIngredients(slug: string, parser: mealie.IngredientP
     // The recipe itself is intact either way — report the parse failure
     // rather than failing the caller's import.
     return { parsed: false, parser, error: error instanceof Error ? error.message : 'Unknown Mealie error' };
+  } finally {
+    endImport(guardKey);
   }
 }
 
@@ -313,7 +344,10 @@ const importMealieRecipeUrl: Tool = {
     }
     try {
       const slug = await mealie.importRecipeFromUrl(importKey, includeTags);
-      const parse = shouldParse ? await parseAndApplyIngredients(slug, parser) : undefined;
+      // Embedded parse writes ONLY to the slug this import just created —
+      // never a pre-existing recipe (fresh imports always have
+      // disableAmount=true, so the no-force overwrite gate stays intact).
+      const parse = shouldParse ? await parseAndApplyIngredients(slug, parser, false) : undefined;
       return {
         imported: true,
         slug,
@@ -343,6 +377,12 @@ const parseMealieRecipeIngredients: Tool = {
         description: 'Ingredient parser: nlp (built-in, fast, default), brute, or openai (group AI provider)',
         default: 'nlp',
       },
+      force: {
+        type: 'boolean',
+        description:
+          'Required to re-parse a recipe that already has structured ingredients (overwrites them; original text lines are preserved in originalText). Default: false',
+        default: false,
+      },
     },
     required: ['slug'],
   },
@@ -356,20 +396,8 @@ const parseMealieRecipeIngredients: Tool = {
       return parser;
     }
 
-    const parseKey = `parse:${slug}`;
-    if (!beginImport(parseKey)) {
-      return {
-        error: true,
-        code: 'PARSE_IN_PROGRESS',
-        message: `A parse for '${slug}' is already running — wait for it to finish instead of retrying.`,
-      };
-    }
-    try {
-      const outcome = await parseAndApplyIngredients(slug, parser);
-      return { slug, url: mealie.recipeUrl(slug), ...outcome };
-    } finally {
-      endImport(parseKey);
-    }
+    const outcome = await parseAndApplyIngredients(slug, parser, params.force === true);
+    return { slug, url: mealie.recipeUrl(slug), ...outcome };
   },
 };
 


### PR DESCRIPTION
## Summary

Imported recipes in Mealie carry ingredients as raw text lines with `settings.disableAmount=true` — no quantity/unit/food structure, so recipe scaling and shopping-list merging (the point of the recipe homestead) don't work. Verified against v3.20.1 source: `POST /api/parser/ingredients` parses lines and matches the group's existing foods/units; recipe `PUT` accepts create-by-name for unmatched ones.

- **`parse_mealie_recipe_ingredients`** (new tool): fetch recipe → parse lines (`nlp` default / `brute` / `openai` via the group AI provider) → write structured ingredients back with `originalText` preserved and `disableAmount` flipped off. Per-slug in-flight guard, 100-line cap, slug+parser validation.
- **`import_mealie_recipe_url`**: runs the same parse pass after import by default (`parseIngredients: false` to opt out). Parse failure is reported in the result but never fails the durable import.
- Registry test 49 → 50; parser-validation tests added; README updated.

## Testing
- tsc + eslint clean locally (vitest needs esbuild exec — CI runs it)
- Live eval after release: run `parse_mealie_recipe_ingredients` on `gyudon-3` with nlp vs openai and compare

🤖 Generated with [Claude Code](https://claude.com/claude-code)